### PR TITLE
chore: fix repo-wide rustfmt and clippy issues for current stable toolchain

### DIFF
--- a/src/cache/matcher.rs
+++ b/src/cache/matcher.rs
@@ -151,12 +151,9 @@ mod tests {
             exclude: vec!["**/*.test.ts".to_string()],
             env: vec![],
         };
-        let m = TargetInputMatcher::build(
-            Path::new("/p"),
-            &inputs(&["src/**/*.ts"], &[]),
-            Some(&user),
-        )
-        .unwrap();
+        let m =
+            TargetInputMatcher::build(Path::new("/p"), &inputs(&["src/**/*.ts"], &[]), Some(&user))
+                .unwrap();
         assert!(m.matches_relative(Path::new("src/foo.ts")));
         assert!(!m.matches_relative(Path::new("src/foo.test.ts")));
     }
@@ -168,12 +165,9 @@ mod tests {
             exclude: vec![],
             env: vec![],
         };
-        let m = TargetInputMatcher::build(
-            Path::new("/p"),
-            &inputs(&["src/**/*.ts"], &[]),
-            Some(&user),
-        )
-        .unwrap();
+        let m =
+            TargetInputMatcher::build(Path::new("/p"), &inputs(&["src/**/*.ts"], &[]), Some(&user))
+                .unwrap();
         assert!(m.matches_relative(Path::new("src/foo.ts")));
         assert!(m.matches_relative(Path::new("extra/data.json")));
     }

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -1487,5 +1487,4 @@ mod tests {
         assert_eq!(result.output, "test output");
         assert_eq!(result.duration_ms, 100);
     }
-
 }

--- a/src/graph/targets.rs
+++ b/src/graph/targets.rs
@@ -152,16 +152,16 @@ impl TargetGraph {
                     in_stack[node.index()] = true;
                     path.push(node);
                 }
-                DfsEvent::TreeEdge(_, target) | DfsEvent::BackEdge(_, target) => {
-                    if in_stack[target.index()] {
-                        // Found a cycle - extract it
-                        let cycle_start = path.iter().position(|&n| n == target).unwrap();
-                        let cycle: Vec<String> = path[cycle_start..]
-                            .iter()
-                            .map(|&idx| self.graph[idx].address.clone())
-                            .collect();
-                        return Control::Break(cycle);
-                    }
+                DfsEvent::TreeEdge(_, target) | DfsEvent::BackEdge(_, target)
+                    if in_stack[target.index()] =>
+                {
+                    // Found a cycle - extract it
+                    let cycle_start = path.iter().position(|&n| n == target).unwrap();
+                    let cycle: Vec<String> = path[cycle_start..]
+                        .iter()
+                        .map(|&idx| self.graph[idx].address.clone())
+                        .collect();
+                    return Control::Break(cycle);
                 }
                 DfsEvent::Finish(node, _) => {
                     in_stack[node.index()] = false;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,8 @@ use aster::config::find_workspace_root;
 use aster::discovery::{discover_projects, DiscoveredProject};
 use aster::executor::logs::LogStore;
 use aster::executor::{
-    collect_target_deps, compute_target_levels, parse_target_address, setup_signal_handler, Executor,
+    collect_target_deps, compute_target_levels, parse_target_address, setup_signal_handler,
+    Executor,
 };
 use aster::git::{affected_with_dependents, files_to_projects, AffectedDetector};
 use aster::graph::{build_graph, build_target_graph, find_cycle, format_path, TargetGraph};
@@ -1125,7 +1126,12 @@ fn run() -> Result<()> {
                 } else {
                     projects.iter().collect()
                 };
-                executor.execute(&run_args.target, &executor_projects, &graph, Some(&primary_projects))
+                executor.execute(
+                    &run_args.target,
+                    &executor_projects,
+                    &graph,
+                    Some(&primary_projects),
+                )
             };
 
             // Output results based on mode
@@ -1643,9 +1649,7 @@ fn handle_watch(
             }
             resolved.push(format!("{entry}:{default_target}"));
         } else {
-            return Err(anyhow::anyhow!(
-                "target must start with '//': {entry}"
-            ));
+            return Err(anyhow::anyhow!("target must start with '//': {entry}"));
         }
     }
 
@@ -1653,7 +1657,12 @@ fn handle_watch(
     if !lang.is_empty() {
         let project_lang: HashMap<String, String> = projects
             .iter()
-            .map(|p| (format!("//{}", p.relative_path.display()), p.plugin_name.clone()))
+            .map(|p| {
+                (
+                    format!("//{}", p.relative_path.display()),
+                    p.plugin_name.clone(),
+                )
+            })
             .collect();
         resolved.retain(|addr| {
             let project_addr = addr.rsplit_once(':').map(|(p, _)| p).unwrap_or(addr);

--- a/src/plugins/python.rs
+++ b/src/plugins/python.rs
@@ -1244,7 +1244,9 @@ name = "mypackage"
         // deps cache should include .venv/pyvenv.cfg so that deleting or
         // recreating the venv invalidates the cache
         assert!(
-            inputs.config_files.contains(&".venv/pyvenv.cfg".to_string()),
+            inputs
+                .config_files
+                .contains(&".venv/pyvenv.cfg".to_string()),
             "deps cache_inputs should include .venv/pyvenv.cfg"
         );
 
@@ -1261,7 +1263,9 @@ name = "mypackage"
         for target in &["test", "lint", "format"] {
             let inputs = plugin.cache_inputs(target);
             assert!(
-                !inputs.config_files.contains(&".venv/pyvenv.cfg".to_string()),
+                !inputs
+                    .config_files
+                    .contains(&".venv/pyvenv.cfg".to_string()),
                 "{target} cache_inputs should not include .venv/pyvenv.cfg"
             );
         }

--- a/src/watch/event_loop.rs
+++ b/src/watch/event_loop.rs
@@ -73,12 +73,7 @@ pub fn run_watch(
     let requested_non_stream: HashSet<String> = plan
         .requested
         .iter()
-        .filter(|addr| {
-            !plan
-                .targets
-                .iter()
-                .any(|t| t.address == **addr && t.stream)
-        })
+        .filter(|addr| !plan.targets.iter().any(|t| t.address == **addr && t.stream))
         .cloned()
         .collect();
 
@@ -228,11 +223,7 @@ where
 
         // Drain additional events within the debounce window.
         let deadline = Instant::now() + opts.debounce;
-        loop {
-            let remaining = match deadline.checked_duration_since(Instant::now()) {
-                Some(d) => d,
-                None => break,
-            };
+        while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
             match event_rx.recv_timeout(remaining) {
                 Ok(Ok(ev)) => process_event(
                     &ev,
@@ -405,11 +396,7 @@ mod tests {
     use std::collections::HashMap as StdHashMap;
     use std::path::PathBuf;
 
-    fn mk_project(
-        rel: &str,
-        abs_root: &str,
-        targets: &[(&str, Vec<&str>)],
-    ) -> DiscoveredProject {
+    fn mk_project(rel: &str, abs_root: &str, targets: &[(&str, Vec<&str>)]) -> DiscoveredProject {
         let mut target_map = StdHashMap::new();
         for (name, deps) in targets {
             target_map.insert(
@@ -490,7 +477,11 @@ mod tests {
         }
     }
 
-    fn run_event(f: &Fixture, event: &Event, suppress_until: Instant) -> (HashSet<String>, Vec<PathBuf>) {
+    fn run_event(
+        f: &Fixture,
+        event: &Event,
+        suppress_until: Instant,
+    ) -> (HashSet<String>, Vec<PathBuf>) {
         let mut pending = HashSet::new();
         let mut trigger_paths = Vec::new();
         process_event(
@@ -730,7 +721,10 @@ mod tests {
 
     impl Dispatches {
         fn record(&self, primary: HashSet<String>, delay: Option<Duration>) {
-            self.calls.lock().unwrap().push(DispatchCall { primary, delay });
+            self.calls
+                .lock()
+                .unwrap()
+                .push(DispatchCall { primary, delay });
         }
 
         fn count(&self) -> usize {
@@ -1056,10 +1050,7 @@ mod tests {
 
         // poll_stream fires every 250ms — wait for at least 2 ticks.
         assert!(
-            wait_until(
-                || ticks.load(Ordering::SeqCst) >= 2,
-                Duration::from_secs(2),
-            ),
+            wait_until(|| ticks.load(Ordering::SeqCst) >= 2, Duration::from_secs(2),),
             "idle tick never fired"
         );
 

--- a/src/watch/plan.rs
+++ b/src/watch/plan.rs
@@ -81,12 +81,9 @@ impl WatchPlan {
                 .map(|p| p.cache_inputs(&node.target_name))
                 .unwrap_or_default();
 
-            let matcher = TargetInputMatcher::build(
-                &project.root,
-                &plugin_inputs,
-                target_def.cache.as_ref(),
-            )
-            .with_context(|| format!("failed to build input matcher for {addr}"))?;
+            let matcher =
+                TargetInputMatcher::build(&project.root, &plugin_inputs, target_def.cache.as_ref())
+                    .with_context(|| format!("failed to build input matcher for {addr}"))?;
 
             let uses_fallback = !matcher.has_patterns();
 
@@ -112,7 +109,7 @@ impl WatchPlan {
             .iter()
             .map(|t| (t.project_root.clone(), t.project_address.clone()))
             .collect();
-        project_by_root.sort_by(|a, b| b.0.as_os_str().len().cmp(&a.0.as_os_str().len()));
+        project_by_root.sort_by_key(|p| std::cmp::Reverse(p.0.as_os_str().len()));
         project_by_root.dedup_by(|a, b| a.0 == b.0);
 
         Ok(Self {
@@ -448,8 +445,16 @@ mod tests {
         )
         .unwrap();
 
-        let a = plan.targets.iter().find(|t| t.address == "//a:build").unwrap();
-        let b = plan.targets.iter().find(|t| t.address == "//b:build").unwrap();
+        let a = plan
+            .targets
+            .iter()
+            .find(|t| t.address == "//a:build")
+            .unwrap();
+        let b = plan
+            .targets
+            .iter()
+            .find(|t| t.address == "//b:build")
+            .unwrap();
         assert!(!a.uses_fallback, "nodejs plugin provides inputs");
         assert!(b.uses_fallback);
 

--- a/src/watch/stream.rs
+++ b/src/watch/stream.rs
@@ -333,7 +333,8 @@ mod tests {
         let dir = tempdir();
         let mut sup = StreamSupervisor::new(Duration::from_secs(1));
         // A child that exits immediately with code 0.
-        sup.spawn("//a:dev", &mk_target("true"), dir.path()).unwrap();
+        sup.spawn("//a:dev", &mk_target("true"), dir.path())
+            .unwrap();
 
         // Give the short-lived child time to exit.
         std::thread::sleep(Duration::from_millis(200));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1737,11 +1737,7 @@ fn test_lang_filter_invalid_language() {
     let tmp = TempDir::new().unwrap();
     setup_workspace(&tmp);
 
-    write_package_json(
-        &tmp,
-        "services/api/package.json",
-        r#"{"name": "api"}"#,
-    );
+    write_package_json(&tmp, "services/api/package.json", r#"{"name": "api"}"#);
 
     // Invalid language should produce an error
     let output = Command::new(env!("CARGO_BIN_EXE_aster"))

--- a/tests/watch_tests.rs
+++ b/tests/watch_tests.rs
@@ -282,7 +282,11 @@ fn watch_ignores_node_modules_changes() {
     setup_workspace(&tmp);
     write(&tmp, "libs/core/package.json", &nodejs_package("core"));
     write(&tmp, "libs/core/src/index.ts", "export const x = 1;\n");
-    write(&tmp, "libs/core/node_modules/foo/index.js", "module.exports = 1;\n");
+    write(
+        &tmp,
+        "libs/core/node_modules/foo/index.js",
+        "module.exports = 1;\n",
+    );
 
     let mut cmd = Command::new(aster_bin());
     cmd.current_dir(tmp.path())
@@ -338,7 +342,11 @@ fn watch_reruns_dependent_target_on_dep_source_change() {
     // Give notify time to register the watch.
     thread::sleep(Duration::from_millis(500));
     // Touch the core source file.
-    fs::write(tmp.path().join("libs/core/src/index.ts"), "export const x = 2;\n").unwrap();
+    fs::write(
+        tmp.path().join("libs/core/src/index.ts"),
+        "export const x = 2;\n",
+    )
+    .unwrap();
 
     // Expect the change banner AND the start of libs/core:build.
     let change = wait_for_line(&rx, "change:", Duration::from_secs(8));


### PR DESCRIPTION

This PR applies formatting and lint fixes across the codebase to ensure compatibility with the latest stable Rust toolchain. The CI Lint job (`cargo fmt --check`, `cargo clippy -- -D warnings`) was failing due to code drift under newer versions of rustfmt and clippy. No behavior changes are introduced.

- Reformatted 9 files using `cargo fmt`
- Fixed clippy lints:
  - Collapsible `if` in `graph/targets.rs`
  - Replaced `while let` loop with `while let Some(...)` in `watch/event_loop.rs`
  - Replaced `sort_by` with `sort_by_key` in `watch/plan.rs`
- Reformatted long function calls and assertions for consistency and readability
- Ensured all code passes `cargo fmt` and `cargo clippy -- -D warnings` under the current stable toolchain

This is a maintenance update to keep CI green and code style consistent.
