### PR TITLE
feat: ignore configured paths in affected analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ aster affected test --dry-run
 aster affected test --dependents
 ```
 
+Exclude workspace metadata or generated files from affected analysis in the
+root `aster.toml`. Patterns are workspace-relative and are applied to Git changes
+before Aster maps files to projects:
+
+```toml
+[affected]
+ignore = [
+  ".agents/**",
+  ".claude/skills/**",
+  "docs/generated/**",
+]
+```
+
+This setting only controls `aster affected`; the top-level `ignore` setting
+continues to control project discovery.
+
 ### Heterogeneous runs
 
 Run different targets on different projects:

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,4 +5,6 @@ pub use project::{
     find_aster_toml, parse_aster_toml, AliasTargetConfig, AsterToml, CacheConfig, RichTargetConfig,
     TargetConfig,
 };
-pub use workspace::{find_workspace_root, WatchWorkspaceConfig, WorkspaceConfig};
+pub use workspace::{
+    find_workspace_root, AffectedWorkspaceConfig, WatchWorkspaceConfig, WorkspaceConfig,
+};

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -12,6 +12,18 @@ pub struct WorkspaceConfig {
     /// Watch mode configuration
     #[serde(default)]
     pub watch: WatchWorkspaceConfig,
+
+    /// Affected-command configuration
+    #[serde(default)]
+    pub affected: AffectedWorkspaceConfig,
+}
+
+/// Configuration controlling which Git changes participate in affected analysis.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct AffectedWorkspaceConfig {
+    /// Workspace-relative glob patterns excluded from affected analysis.
+    #[serde(default)]
+    pub ignore: Vec<String>,
 }
 
 /// Watch-mode configuration controlling fs-event ignore and suppression behavior.
@@ -50,7 +62,8 @@ impl WorkspaceConfig {
             .with_context(|| format!("Failed to read {}", config_path.display()))?;
 
         // Parse TOML - workspace config fields are at the top level
-        let config: WorkspaceConfig = toml::from_str(&content).unwrap_or_default();
+        let config: WorkspaceConfig = toml::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", config_path.display()))?;
 
         Ok(config)
     }
@@ -193,6 +206,27 @@ debounce_ms = 500
     }
 
     #[test]
+    fn test_workspace_config_load_with_affected_section() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+
+        fs::write(
+            root.join("aster.toml"),
+            r#"
+[affected]
+ignore = [".agents/**", ".claude/skills/**"]
+"#,
+        )
+        .unwrap();
+
+        let config = WorkspaceConfig::load(root).unwrap();
+        assert_eq!(
+            config.affected.ignore,
+            vec![".agents/**".to_string(), ".claude/skills/**".to_string()]
+        );
+    }
+
+    #[test]
     fn test_workspace_config_watch_defaults() {
         let temp = TempDir::new().unwrap();
         let root = temp.path();
@@ -232,6 +266,7 @@ ignore = ["vendor/**", "examples/**"]
 
         let config = WorkspaceConfig::load(root).unwrap();
         assert!(config.ignore.is_empty());
+        assert!(config.affected.ignore.is_empty());
     }
 
     #[test]
@@ -242,6 +277,19 @@ ignore = ["vendor/**", "examples/**"]
         // No aster.toml file
         let config = WorkspaceConfig::load(root).unwrap();
         assert!(config.ignore.is_empty());
+        assert!(config.affected.ignore.is_empty());
+    }
+
+    #[test]
+    fn test_workspace_config_reports_invalid_toml() {
+        let temp = TempDir::new().unwrap();
+        let root = temp.path();
+        fs::write(root.join("aster.toml"), "[affected\nignore = []").unwrap();
+
+        let error = WorkspaceConfig::load(root).err().unwrap();
+
+        assert!(error.to_string().contains("Failed to parse"));
+        assert!(error.to_string().contains("aster.toml"));
     }
 
     #[test]

--- a/src/git/affected.rs
+++ b/src/git/affected.rs
@@ -78,6 +78,7 @@ impl AffectedDetector {
     pub fn uncommitted_changes(&self) -> Result<HashSet<PathBuf>> {
         let mut opts = StatusOptions::new();
         opts.include_untracked(true)
+            .recurse_untracked_dirs(true)
             .include_ignored(false)
             .include_unmodified(false);
 
@@ -195,6 +196,24 @@ mod tests {
         let changes = detector.uncommitted_changes().unwrap();
 
         assert!(changes.contains(&PathBuf::from("new_file.txt")));
+    }
+
+    #[test]
+    fn test_uncommitted_changes_recurses_into_untracked_directories() {
+        let tmp = TempDir::new().unwrap();
+        setup_git_repo(&tmp);
+        fs::create_dir_all(tmp.path().join(".agents/skills/example")).unwrap();
+        fs::write(
+            tmp.path().join(".agents/skills/example/SKILL.md"),
+            "content",
+        )
+        .unwrap();
+
+        let detector = AffectedDetector::new(tmp.path()).unwrap();
+        let changes = detector.uncommitted_changes().unwrap();
+
+        assert!(changes.contains(&PathBuf::from(".agents/skills/example/SKILL.md")));
+        assert!(!changes.contains(&PathBuf::from(".agents/")));
     }
 
     #[test]

--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -1,0 +1,77 @@
+//! Workspace-configured filtering for Git changes used by `aster affected`.
+
+use anyhow::{Context, Result};
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+use crate::config::AffectedWorkspaceConfig;
+
+/// Compiled workspace-relative patterns excluded from affected analysis.
+pub struct AffectedIgnore {
+    patterns: GlobSet,
+}
+
+impl AffectedIgnore {
+    pub fn build(config: &AffectedWorkspaceConfig) -> Result<Self> {
+        let mut builder = GlobSetBuilder::new();
+        for pattern in &config.ignore {
+            builder.add(
+                Glob::new(pattern)
+                    .with_context(|| format!("invalid affected.ignore pattern: {pattern}"))?,
+            );
+        }
+
+        let patterns = builder
+            .build()
+            .context("failed to build affected.ignore glob set")?;
+        Ok(Self { patterns })
+    }
+
+    pub fn is_ignored(&self, path: &Path) -> bool {
+        self.patterns.is_match(path)
+    }
+
+    pub fn filter(&self, paths: HashSet<PathBuf>) -> HashSet<PathBuf> {
+        paths
+            .into_iter()
+            .filter(|path| !self.is_ignored(path))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn filters_ignored_paths_and_keeps_other_paths() {
+        let config = AffectedWorkspaceConfig {
+            ignore: vec![".agents/**".to_string(), "docs/generated/**".to_string()],
+        };
+        let ignore = AffectedIgnore::build(&config).unwrap();
+        let paths = [
+            PathBuf::from(".agents/skills/example/SKILL.md"),
+            PathBuf::from("docs/generated/api.md"),
+            PathBuf::from("src/main.rs"),
+        ]
+        .into_iter()
+        .collect();
+
+        let filtered = ignore.filter(paths);
+
+        assert_eq!(filtered, HashSet::from([PathBuf::from("src/main.rs")]));
+    }
+
+    #[test]
+    fn rejects_invalid_patterns() {
+        let config = AffectedWorkspaceConfig {
+            ignore: vec!["[".to_string()],
+        };
+
+        let error = AffectedIgnore::build(&config).err().unwrap();
+        assert!(error
+            .to_string()
+            .contains("invalid affected.ignore pattern: ["));
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -5,6 +5,8 @@
 
 pub mod affected;
 pub mod file_owner;
+pub mod ignore;
 
 pub use affected::AffectedDetector;
 pub use file_owner::{affected_with_dependents, files_to_projects};
+pub use ignore::AffectedIgnore;

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,14 +14,14 @@ use aster::cli::{
     print_summary, select_projects, Cli, Commands, GraphOutput, OutputMode, ProjectCommands,
     ProjectInfo, WhyOutput,
 };
-use aster::config::find_workspace_root;
+use aster::config::{find_workspace_root, WorkspaceConfig};
 use aster::discovery::{discover_projects, DiscoveredProject};
 use aster::executor::logs::LogStore;
 use aster::executor::{
     collect_target_deps, compute_target_levels, parse_target_address, setup_signal_handler,
     Executor,
 };
-use aster::git::{affected_with_dependents, files_to_projects, AffectedDetector};
+use aster::git::{affected_with_dependents, files_to_projects, AffectedDetector, AffectedIgnore};
 use aster::graph::{build_graph, build_target_graph, find_cycle, format_path, TargetGraph};
 use aster::plugins::{
     ElixirPlugin, GoPlugin, NodeJsPlugin, PluginRegistry, PythonPlugin, RustPlugin, Target,
@@ -414,8 +414,19 @@ fn run() -> Result<()> {
                     )
                 })?;
 
+            // Affected ignores are distinct from discovery ignores: they remove
+            // matching Git changes before ownership, rationale, and files-list handling.
+            let workspace_config = WorkspaceConfig::load(&workspace_root)?;
+            let unfiltered_count = changed_files.len();
+            let changed_files =
+                AffectedIgnore::build(&workspace_config.affected)?.filter(changed_files);
+
             if output_mode == OutputMode::Verbose {
                 eprintln!("[aster] Found {} changed files", changed_files.len());
+                let ignored_count = unfiltered_count - changed_files.len();
+                if ignored_count > 0 {
+                    eprintln!("[aster] Ignored {ignored_count} changed files via affected.ignore");
+                }
                 for file in &changed_files {
                     eprintln!("  - {}", file.display());
                 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -807,6 +807,240 @@ fn test_affected_no_changes() {
 }
 
 #[test]
+fn test_affected_ignore_prevents_root_project_from_claiming_ignored_changes() {
+    let tmp = TempDir::new().unwrap();
+    setup_git_repo(&tmp);
+    write_package_json(
+        &tmp,
+        "package.json",
+        r#"{"name": "workspace", "scripts": {"test": "true"}}"#,
+    );
+    write_aster_toml(
+        &tmp,
+        "aster.toml",
+        r#"
+[affected]
+ignore = [".agents/**/*.md"]
+"#,
+    );
+    git_commit(&tmp, "Initial commit");
+
+    fs::create_dir_all(tmp.path().join(".agents/skills/example")).unwrap();
+    fs::write(
+        tmp.path().join(".agents/skills/example/SKILL.md"),
+        "new untracked skill",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["affected", "test", "--base=HEAD", "--dry-run"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("No projects affected"),
+        "Root project should not claim ignored paths: {stdout}"
+    );
+}
+
+#[test]
+fn test_affected_ignore_filters_verbose_and_dry_run_file_lists() {
+    let tmp = TempDir::new().unwrap();
+    setup_git_repo(&tmp);
+    write_package_json(
+        &tmp,
+        "package.json",
+        r#"{"name": "workspace", "scripts": {"test": "true"}}"#,
+    );
+    write_aster_toml(
+        &tmp,
+        "aster.toml",
+        r#"
+[affected]
+ignore = [".agents/**"]
+
+[targets.test]
+command = "./capture-files.sh {files}"
+capabilities = ["files_list"]
+"#,
+    );
+    fs::write(
+        tmp.path().join("capture-files.sh"),
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > affected-files.txt\n",
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut permissions = fs::metadata(tmp.path().join("capture-files.sh"))
+            .unwrap()
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(tmp.path().join("capture-files.sh"), permissions).unwrap();
+    }
+    fs::create_dir_all(tmp.path().join(".agents/skills/example")).unwrap();
+    fs::write(
+        tmp.path().join(".agents/skills/example/SKILL.md"),
+        "original",
+    )
+    .unwrap();
+    git_commit(&tmp, "Initial commit");
+
+    fs::write(
+        tmp.path().join(".agents/skills/example/SKILL.md"),
+        "updated",
+    )
+    .unwrap();
+    fs::write(
+        tmp.path().join("package.json"),
+        r#"{"name": "workspace", "scripts": {"test": "true"}, "private": true}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args([
+            "--verbose",
+            "affected",
+            "test",
+            "--base=HEAD",
+            "--dry-run",
+            "--only-affected-files",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("//:test"),
+        "Root package should remain affected: {stdout}"
+    );
+    assert!(
+        stdout.contains("package.json"),
+        "Expected real changed file: {stdout}"
+    );
+    assert!(
+        !stdout.contains("SKILL.md") && !stderr.contains("SKILL.md"),
+        "Ignored file leaked into affected output: stdout={stdout}, stderr={stderr}"
+    );
+    assert!(
+        stderr.contains("Found 1 changed files")
+            && stderr.contains("Ignored 1 changed files via affected.ignore"),
+        "Expected verbose counts after filtering: {stderr}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args([
+            "affected",
+            "test",
+            "--base=HEAD",
+            "--only-affected-files",
+            "--no-cache",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let affected_files =
+        fs::read_to_string(tmp.path().join("affected-files.txt")).unwrap_or_else(|error| {
+            panic!(
+                "files-list command did not write output: {error}; stdout={}; stderr={}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            )
+        });
+    assert_eq!(affected_files.trim(), "package.json");
+}
+
+#[test]
+fn test_affected_ignore_rejects_invalid_glob() {
+    let tmp = TempDir::new().unwrap();
+    setup_git_repo(&tmp);
+    write_package_json(&tmp, "package.json", r#"{"name": "workspace"}"#);
+    write_aster_toml(
+        &tmp,
+        "aster.toml",
+        r#"
+[affected]
+ignore = ["["]
+"#,
+    );
+    git_commit(&tmp, "Initial commit");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["affected", "test", "--base=HEAD"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid affected.ignore pattern: ["),
+        "Expected invalid pattern context: {stderr}"
+    );
+}
+
+#[test]
+fn test_affected_ignore_filters_rename_paths_independently() {
+    let tmp = TempDir::new().unwrap();
+    setup_git_repo(&tmp);
+    write_package_json(
+        &tmp,
+        "package.json",
+        r#"{"name": "workspace", "scripts": {"test": "true"}}"#,
+    );
+    write_aster_toml(
+        &tmp,
+        "aster.toml",
+        r#"
+[affected]
+ignore = [".agents/**"]
+"#,
+    );
+    fs::write(tmp.path().join("runtime.js"), "content").unwrap();
+    git_commit(&tmp, "Initial commit");
+
+    fs::create_dir_all(tmp.path().join(".agents/archive")).unwrap();
+    let status = Command::new("git")
+        .args(["mv", "runtime.js", ".agents/archive/runtime.js"])
+        .current_dir(tmp.path())
+        .status()
+        .unwrap();
+    assert!(status.success());
+    git_commit(&tmp, "Move runtime file into ignored metadata");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args([
+            "affected",
+            "test",
+            "--base=HEAD~1",
+            "--head=HEAD",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("runtime.js"),
+        "The non-ignored old rename path should remain affected: {stdout}"
+    );
+    assert!(
+        !stdout.contains(".agents/archive/runtime.js"),
+        "The ignored new rename path should be filtered: {stdout}"
+    );
+}
+
+#[test]
 fn test_affected_detects_uncommitted_changes() {
     let tmp = TempDir::new().unwrap();
     setup_git_repo(&tmp);

--- a/tests/watch_tests.rs
+++ b/tests/watch_tests.rs
@@ -32,7 +32,25 @@ fn aster_bin() -> &'static str {
 /// kill the process.
 fn spawn_capturing(mut cmd: Command) -> (std::process::Child, mpsc::Receiver<String>) {
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    // Aster's shutdown handler terminates its process group so streamed target
+    // descendants cannot be orphaned. Give the test child its own group; CI
+    // shells run without job control and would otherwise share the cargo test
+    // process group, causing SIGTERM cleanup to cancel the entire job.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+
     let mut child = cmd.spawn().expect("spawn aster watch");
+    #[cfg(unix)]
+    assert_eq!(
+        unsafe { libc::getpgid(child.id() as i32) },
+        child.id() as i32,
+        "watch test child must own its process group"
+    );
+
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
 


### PR DESCRIPTION
## What changed

Adds an explicit workspace-level `[affected].ignore` configuration for excluding repository-relative Git paths before Aster maps changes to projects.

The filter is applied once, immediately after committed and working-tree changes are collected. The same filtered path set now drives project ownership, verbose diagnostics, dry-run file rationale, and `--only-affected-files`, preventing ignored metadata from leaking into later execution decisions.

Untracked-directory traversal now reports leaf files so fine-grained patterns such as `.agents/**/*.md` behave consistently. Malformed workspace TOML and invalid affected-ignore globs return contextual errors instead of silently disabling configuration.

The watch integration harness now launches Aster in its own Unix process group. Aster intentionally terminates its process group during shutdown; without test isolation, non-interactive CI shells shared that group and were canceled when the test sent SIGTERM to the child.

## Runtime flow

```mermaid
sequenceDiagram
    participant CLI
    participant Config
    participant Git
    participant Filter
    participant Ownership

    CLI->>Config: Load workspace configuration
    Config-->>CLI: Return affected ignore patterns
    CLI->>Git: Collect changed paths
    Git-->>CLI: Return committed and working tree paths
    CLI->>Filter: Remove paths matching configured globs
    alt Paths remain
        Filter-->>Ownership: Forward filtered paths
        Ownership-->>CLI: Return affected projects
    else Every path is ignored
        Filter-->>CLI: Return empty path set
        CLI-->>CLI: Report no projects affected
    end
```

## Type relationships

```mermaid
classDiagram
    class WorkspaceConfig {
        +AffectedWorkspaceConfig affected
    }
    class AffectedWorkspaceConfig {
        +Vec~String~ ignore
    }
    class AffectedIgnore {
        -GlobSet patterns
        +build config
        +is_ignored path
        +filter paths
    }
    class AffectedDetector {
        +all_affected_files base head
        +uncommitted_changes
    }
    class AffectedCommand {
        +map filtered paths
        +run target
    }

    WorkspaceConfig *-- AffectedWorkspaceConfig
    AffectedIgnore ..> AffectedWorkspaceConfig : builds from
    AffectedCommand --> AffectedDetector : collects paths
    AffectedCommand --> AffectedIgnore : filters paths
```

## Scope

CLI, Rust library, and integration-test harness only. No service, frontend, database, API, or infrastructure changes.

The diff is one cohesive feature; more than half is focused integration coverage for ownership, dry-run, files-list, rename, untracked-path, and process-cleanup behavior.

## Risk assessment

Low to medium. The new configuration is opt-in, so existing valid workspaces retain their current affected-project behavior. Workspace TOML that was already malformed now fails with a clear error instead of silently falling back to defaults. Untracked directories are traversed to leaf files, which improves accuracy but may expose more precise paths to existing affected analysis.

The process-group change is test-only and Unix-gated; non-Unix behavior retains the existing child-kill fallback.

## User impact

Repositories can prevent metadata-only or generated-file changes from triggering unrelated project builds:

```toml
[affected]
ignore = [".agents/**", ".claude/skills/**"]
```

Ignored paths no longer appear in verbose output, dry-run rationale, or file-scoped target arguments.

## Testing

- `cargo fmt --all -- --check`
- `cargo test` — 397 unit tests, 58 integration tests, and 3 active watch tests passed; 12 timing/real-monorepo tests intentionally ignored
- `cargo clippy --test watch_tests -- -D warnings`
- `cargo clippy --all-targets` — passed with pre-existing warnings only
- Focused unit coverage for workspace config, invalid TOML/globs, and recursive untracked paths
- Integration coverage for ignored-only root-project changes, mixed ignored and real changes, dry-run/file-list propagation, and rename-boundary behavior
- Watch child process-group isolation is asserted directly and the focused suite passes under a no-job-control session
- Exact firstlanding skill PR reproduction with the new binary — 3 paths ignored, 0 changed files retained, and no projects affected
- Independent design, final diff, and CI-fix reviews found no blockers

## Follow-ups and known issues

Firstlanding still needs to adopt the released Aster version, configure its shared-skill paths, and fix its CI gate to derive `has_affected` from parsed project addresses rather than non-empty human-readable output.
