### PR TITLE
Suppress per-target cache-hit output

### DIFF
--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -131,10 +131,19 @@ pub fn print_summary(
     }
 
     let skipped = results.iter().filter(|r| r.skipped).count();
-    let passed = results.iter().filter(|r| r.success && !r.skipped).count();
+    let cached = results.iter().filter(|r| r.cached).count();
+    let passed = results
+        .iter()
+        .filter(|r| r.success && !r.skipped && !r.cached)
+        .count();
     let failed = results.iter().filter(|r| !r.success).count();
     let total = results.len();
     let total_duration: u128 = results.iter().map(|r| r.duration_ms).sum();
+    let cached_summary = if cached > 0 {
+        format!(", {cached} cached")
+    } else {
+        String::new()
+    };
 
     let context = if is_affected {
         "affected projects"
@@ -145,9 +154,9 @@ pub fn print_summary(
     if mode == OutputMode::Quiet {
         // Single line summary for quiet mode
         if failed > 0 {
-            eprintln!("{passed} passed, {failed} failed");
+            eprintln!("{passed} passed{cached_summary}, {failed} failed");
         } else {
-            eprintln!("{passed} passed");
+            eprintln!("{passed} passed{cached_summary}");
         }
         return;
     }
@@ -156,10 +165,12 @@ pub fn print_summary(
     println!("\n=== Summary ===");
     if skipped > 0 {
         println!(
-            "Ran '{target}' on {total} {context}: {passed} passed, {failed} failed, {skipped} skipped (no target)"
+            "Ran '{target}' on {total} {context}: {passed} passed{cached_summary}, {failed} failed, {skipped} skipped (no target)"
         );
     } else {
-        println!("Ran '{target}' on {total} {context}: {passed} passed, {failed} failed");
+        println!(
+            "Ran '{target}' on {total} {context}: {passed} passed{cached_summary}, {failed} failed"
+        );
     }
     println!("Total time: {total_duration}ms");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1146,24 +1146,34 @@ fn print_heterogeneous_summary(
 ) {
     use console::style;
 
-    let passed = results.iter().filter(|r| r.success && !r.skipped).count();
+    let cached = results.iter().filter(|r| r.cached).count();
+    let passed = results
+        .iter()
+        .filter(|r| r.success && !r.skipped && !r.cached)
+        .count();
     let failed = results.iter().filter(|r| !r.success && !r.skipped).count();
     let skipped = results.iter().filter(|r| r.skipped).count();
+    let cached_summary = if cached > 0 {
+        format!(", {cached} cached")
+    } else {
+        String::new()
+    };
 
     if output_mode == OutputMode::Quiet {
-        println!("{passed} passed, {failed} failed");
+        println!("{passed} passed{cached_summary}, {failed} failed");
         return;
     }
 
     println!();
     println!(
-        "{} {} passed, {} failed{}",
+        "{} {} passed{}, {} failed{}",
         if failed > 0 {
             style("✗").red()
         } else {
             style("✓").green()
         },
         passed,
+        cached_summary,
         failed,
         if skipped > 0 {
             format!(", {skipped} skipped")

--- a/src/ui/progress.rs
+++ b/src/ui/progress.rs
@@ -229,31 +229,9 @@ impl ProgressDisplay {
     }
 
     /// Mark a target as cached (no execution needed)
-    pub fn mark_cached(&mut self, address: &str) {
+    pub fn mark_cached(&mut self, _address: &str) {
         self.cached.fetch_add(1, Ordering::SeqCst);
         self.refresh_status();
-
-        // Show cached status (in all modes - it's useful to see)
-        if self.enabled {
-            if self.ci_mode {
-                // CI mode: include timestamp
-                eprintln!(
-                    "{} {} {} {}",
-                    style(format_timestamp()).dim(),
-                    style("✓").cyan(),
-                    address,
-                    style("cached").cyan()
-                );
-            } else {
-                let msg = format!(
-                    "{} {} {}",
-                    style("✓").cyan(),
-                    address,
-                    style("cached").cyan()
-                );
-                let _ = self.multi.println(msg);
-            }
-        }
     }
 
     /// Mark a target as complete

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1360,6 +1360,68 @@ fn test_target_on_all_runs_all_tests() {
 }
 
 #[test]
+fn test_cached_targets_are_not_printed() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+
+    write_package_json(
+        &tmp,
+        "app/package.json",
+        r#"{"name": "app", "scripts": {"build": "touch built.txt"}}"#,
+    );
+
+    let first = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["build", "--all"])
+        .output()
+        .unwrap();
+    assert!(first.status.success(), "Command failed: {first:?}");
+
+    // The initial Node deps target creates package-lock.json, so run once more
+    // after that input settles before asserting cache-hit behavior.
+    let warm = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["build", "--all"])
+        .output()
+        .unwrap();
+    assert!(warm.status.success(), "Command failed: {warm:?}");
+
+    let cached_json = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["build", "--all", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        cached_json.status.success(),
+        "Command failed: {cached_json:?}"
+    );
+    let cached_output: serde_json::Value =
+        serde_json::from_slice(&cached_json.stdout).expect("valid JSON output");
+    assert!(
+        cached_output["summary"]["cached"].as_u64().unwrap_or(0) > 0,
+        "Expected the second run to hit the cache: {cached_output}"
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["build", "--all"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "Command failed: {output:?}");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains(" cached"),
+        "Cache-hit targets should not be printed: {stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 passed, 2 cached, 0 failed"),
+        "Expected one consolidated cache count: {stdout}"
+    );
+}
+
+#[test]
 fn test_verbose_shows_primary_project_count() {
     let tmp = TempDir::new().unwrap();
     setup_workspace(&tmp);


### PR DESCRIPTION
## Summary

- stop printing one persistent terminal row per cached target
- retain a single aggregate cached count in live progress and final summaries
- keep exact cache-hit metadata in JSON output
- distinguish executed passes from cached targets in human summaries

## Validation

- `cargo test --all-targets --all-features` (493 tests)
- `cargo clippy --all-targets --all-features -- -D warnings`
- focused end-to-end cache output regression
- autoreview clean with no actionable findings