### PR TITLE
Publish native Linux distribution packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,25 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  linux-packages:
+    name: Linux packages
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: "1.88"
+      - run: cargo build --locked --release
+      - name: Install nFPM
+        run: |
+          scripts/install-nfpm "${RUNNER_TEMP}/nfpm"
+          echo "${RUNNER_TEMP}/nfpm" >> "${GITHUB_PATH}"
+      - name: Build native packages
+        run: |
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+          scripts/package-linux "${version}" target/release/aster dist
+      - name: Smoke-test native packages
+        run: |
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -1)"
+          scripts/test-linux-packages "${version}" dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
+          toolchain: "1.88"
           components: clippy, rustfmt
       - name: Validate tag and package version
         id: version
@@ -46,7 +47,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             artifact: aster-linux-x64
           - target: x86_64-apple-darwin
             os: macos-15-intel
@@ -58,17 +59,31 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
+          toolchain: "1.88"
           targets: ${{ matrix.target }}
       - run: cargo build --locked --release --target "${{ matrix.target }}"
       - name: Smoke test
         run: target/${{ matrix.target }}/release/aster --version
       - name: Package
         shell: bash
-        run: tar -C "target/${{ matrix.target }}/release" -czf "${{ matrix.artifact }}.tar.gz" aster
+        run: |
+          mkdir dist
+          tar -C "target/${{ matrix.target }}/release" -czf "dist/${{ matrix.artifact }}.tar.gz" aster
+      - name: Install nFPM
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          scripts/install-nfpm "${RUNNER_TEMP}/nfpm"
+          echo "${RUNNER_TEMP}/nfpm" >> "${GITHUB_PATH}"
+      - name: Build native Linux packages
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: scripts/package-linux "${{ needs.verify.outputs.version }}" "target/${{ matrix.target }}/release/aster" dist
+      - name: Smoke-test native Linux packages
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: scripts/test-linux-packages "${{ needs.verify.outputs.version }}" dist
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}.tar.gz
+          path: dist/
           if-no-files-found: error
 
   release:
@@ -86,16 +101,18 @@ jobs:
       - name: Create checksums
         run: |
           mkdir release-assets
-          find artifacts -name '*.tar.gz' -exec cp '{}' release-assets/ \;
+          find artifacts -type f \
+            \( -name '*.tar.gz' -o -name '*.deb' -o -name '*.rpm' -o -name '*.pkg.tar.zst' \) \
+            -exec cp '{}' release-assets/ \;
           cd release-assets
-          sha256sum ./*.tar.gz | sed 's#  \./#  #' > ../SHA256SUMS
+          sha256sum ./* | sed 's#  \./#  #' > ../SHA256SUMS
       - uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
         with:
-          subject-path: release-assets/*.tar.gz
+          subject-path: release-assets/*
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: |
-            release-assets/*.tar.gz
+            release-assets/*
             SHA256SUMS
           generate_release_notes: true
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ cargo install --git https://github.com/ArchAstro/aster.git --locked
 Prebuilt release archives are available for Linux x86-64, macOS x86-64, and
 macOS Apple Silicon. Windows is not currently built or tested by the project.
 
+### Native Linux packages
+
+Tagged releases also include native x86-64 packages for Debian/Ubuntu, RPM-based
+distributions, and Arch Linux. Download the package for your distribution from
+the GitHub release, then install it with the system package manager:
+
+```console
+sudo apt install ./aster_VERSION_amd64.deb
+sudo dnf install ./aster-VERSION-1.x86_64.rpm
+sudo pacman -U ./aster-VERSION-1-x86_64.pkg.tar.zst
+```
+
+These packages currently target x86-64 Linux systems with glibc 2.35 or newer.
+
 ## Quick start
 
 Run the same target across a workspace:

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,45 @@
+name: aster
+arch: amd64
+platform: linux
+version: ${ASTER_VERSION}
+release: "1"
+section: devel
+priority: optional
+maintainer: ArchAstro
+description: Build orchestration for polyglot monorepos
+vendor: ArchAstro
+homepage: https://github.com/ArchAstro/aster
+license: MIT
+provides:
+  - aster
+contents:
+  - src: ${ASTER_BINARY}
+    dst: /usr/bin/aster
+    expand: true
+    file_info:
+      mode: 0755
+  - src: LICENSE
+    dst: /usr/share/licenses/aster/LICENSE
+    file_info:
+      mode: 0644
+overrides:
+  deb:
+    depends:
+      - libc6 (>= 2.35)
+      - libgcc-s1
+      - libssl3 | libssl3t64
+      - zlib1g
+  rpm:
+    depends:
+      - glibc >= 2.35
+      - libgcc
+      - openssl-libs
+      - zlib
+  archlinux:
+    depends:
+      - gcc-libs
+      - glibc>=2.35
+      - openssl
+      - zlib
+archlinux:
+  packager: ArchAstro

--- a/scripts/install-nfpm
+++ b/scripts/install-nfpm
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <install-directory>" >&2
+  exit 2
+fi
+
+readonly version="2.47.0"
+readonly archive="nfpm_${version}_Linux_x86_64.tar.gz"
+readonly checksum="0660ca602b2d2d2ae4781a06c692b3eeb9d437ffea05b831d76e41f4a3188783"
+readonly url="https://github.com/goreleaser/nfpm/releases/download/v${version}/${archive}"
+readonly install_dir="$1"
+
+mkdir -p "${install_dir}"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+curl --fail --location --silent --show-error "${url}" --output "${tmp_dir}/${archive}"
+echo "${checksum}  ${tmp_dir}/${archive}" | sha256sum --check --status
+tar -xzf "${tmp_dir}/${archive}" -C "${install_dir}" nfpm
+"${install_dir}/nfpm" --version

--- a/scripts/package-linux
+++ b/scripts/package-linux
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <version> <aster-binary> <output-directory>" >&2
+  exit 2
+fi
+
+readonly version="$1"
+readonly binary="$2"
+readonly output_dir="$3"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly repo_root
+
+if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "version must use MAJOR.MINOR.PATCH format: ${version}" >&2
+  exit 2
+fi
+
+if [[ ! -x "${binary}" ]]; then
+  echo "aster binary is missing or not executable: ${binary}" >&2
+  exit 2
+fi
+
+if ! command -v nfpm >/dev/null 2>&1; then
+  echo "nfpm is required; run scripts/install-nfpm first" >&2
+  exit 2
+fi
+
+mkdir -p "${output_dir}"
+absolute_binary="$(cd "$(dirname "${binary}")" && pwd)/$(basename "${binary}")"
+readonly absolute_binary
+absolute_output="$(cd "${output_dir}" && pwd)"
+readonly absolute_output
+
+export ASTER_VERSION="${version}"
+export ASTER_BINARY="${absolute_binary}"
+
+nfpm package \
+  --config "${repo_root}/packaging/nfpm.yaml" \
+  --packager deb \
+  --target "${absolute_output}/aster_${version}_amd64.deb"
+nfpm package \
+  --config "${repo_root}/packaging/nfpm.yaml" \
+  --packager rpm \
+  --target "${absolute_output}/aster-${version}-1.x86_64.rpm"
+nfpm package \
+  --config "${repo_root}/packaging/nfpm.yaml" \
+  --packager archlinux \
+  --target "${absolute_output}/aster-${version}-1-x86_64.pkg.tar.zst"

--- a/scripts/test-linux-packages
+++ b/scripts/test-linux-packages
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <version> <package-directory>" >&2
+  exit 2
+fi
+
+readonly version="$1"
+readonly package_dir="$2"
+readonly deb="${package_dir}/aster_${version}_amd64.deb"
+readonly rpm="${package_dir}/aster-${version}-1.x86_64.rpm"
+readonly arch="${package_dir}/aster-${version}-1-x86_64.pkg.tar.zst"
+readonly debian_image="debian:bookworm-slim@sha256:7b140f374b289a7c2befc338f42ebe6441b7ea838a042bbd5acbfca6ec875818"
+readonly fedora_image="fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898"
+readonly archlinux_image="archlinux:base@sha256:3406a568f45d68f0bef35dc80b3eacec8bda59b0292b2e50d5932ba1667f20cf"
+
+if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "version must use MAJOR.MINOR.PATCH format: ${version}" >&2
+  exit 2
+fi
+
+for package in "${deb}" "${rpm}" "${arch}"; do
+  if [[ ! -f "${package}" ]]; then
+    echo "missing package: ${package}" >&2
+    exit 1
+  fi
+done
+
+absolute_package_dir="$(cd "${package_dir}" && pwd)"
+readonly absolute_package_dir
+
+docker run --rm \
+  --env "ASTER_VERSION=${version}" \
+  --volume "${absolute_package_dir}:/packages:ro" \
+  "${debian_image}" \
+  bash -euc '
+    apt-get update
+    apt-get install --yes "/packages/aster_${ASTER_VERSION}_amd64.deb"
+    test "$(aster --version)" = "aster ${ASTER_VERSION}"
+    dpkg --status aster
+  '
+
+docker run --rm \
+  --env "ASTER_VERSION=${version}" \
+  --volume "${absolute_package_dir}:/packages:ro" \
+  "${fedora_image}" \
+  bash -euc '
+    dnf --assumeyes install "/packages/aster-${ASTER_VERSION}-1.x86_64.rpm"
+    test "$(aster --version)" = "aster ${ASTER_VERSION}"
+    rpm --query --info aster
+  '
+
+docker run --rm \
+  --env "ASTER_VERSION=${version}" \
+  --volume "${absolute_package_dir}:/packages:ro" \
+  "${archlinux_image}" \
+  bash -euc '
+    pacman --noconfirm --upgrade "/packages/aster-${ASTER_VERSION}-1-x86_64.pkg.tar.zst"
+    test "$(aster --version)" = "aster ${ASTER_VERSION}"
+    pacman --query --info aster
+  '


### PR DESCRIPTION
## Summary

- publish `.deb`, `.rpm`, and Arch Linux `.pkg.tar.zst` assets for x86-64 releases
- build Linux binaries on Ubuntu 22.04 for a glibc 2.35 compatibility floor
- declare Debian, RPM, and Arch-specific runtime dependencies
- install and execute packages in clean Debian, Fedora 44, and Arch Linux environments
- checksum and attest native packages alongside existing release archives
- pin Rust 1.88, nFPM, and validation container images

## Validation

- 492 Rust tests
- strict Clippy and rustdoc
- ShellCheck and actionlint
- local `.deb`, `.rpm`, and `.pkg.tar.zst` generation and metadata inspection
- Fedora 44 RPM install/execute smoke test
- Arch Linux pacman install/execute smoke test
- autoreview clean after resolving all findings