### PR TITLE
feat: add supervised development services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,8 +107,10 @@ dependencies = [
  "clap",
  "console",
  "crossbeam-channel",
+ "crossterm",
  "dirs",
  "fs2",
+ "getrandom 0.3.4",
  "git2",
  "globset",
  "humantime",
@@ -112,6 +120,7 @@ dependencies = [
  "notify",
  "petgraph",
  "predicates",
+ "ratatui",
  "regex",
  "serde",
  "serde_json",
@@ -120,6 +129,7 @@ dependencies = [
  "tempfile",
  "toml",
  "walkdir",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -165,6 +175,21 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -244,6 +269,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,7 +290,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.61.2",
 ]
 
@@ -305,6 +344,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.13.1",
+ "crossterm_winapi",
+ "mio 1.2.2",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +376,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -350,6 +448,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "encode_unicode"
@@ -482,13 +586,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -522,6 +638,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -568,6 +686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "ignore"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,9 +725,18 @@ checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "unit-prefix",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -627,10 +760,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -720,15 +875,39 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "memchr"
@@ -746,6 +925,18 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -768,7 +959,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.48.0",
 ]
@@ -799,6 +990,35 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "petgraph"
@@ -880,9 +1100,45 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.13.1",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "redox_users"
@@ -926,6 +1182,19 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -933,7 +1202,7 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -944,6 +1213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,6 +1226,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -1028,16 +1309,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.2",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "syn"
@@ -1070,7 +1416,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1154,10 +1500,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unit-prefix"
@@ -1207,6 +1576,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1359,7 +1737,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1377,13 +1764,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -1393,10 +1796,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1405,10 +1820,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1417,16 +1850,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1436,6 +1887,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,6 +128,8 @@ dependencies = [
  "shell-words",
  "tempfile",
  "toml",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
  "walkdir",
  "windows-sys 0.59.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ console = "0.16"
 indicatif = "0.18"
 chrono = { version = "0.4", features = ["clock"] }
 globset = "0.4"
+getrandom = "0.3"
 fs2 = "0.4"
 sha2 = "0.10"
 walkdir = "2"
@@ -34,6 +35,20 @@ notify = "6.1"
 crossbeam-channel = "0.5"
 humantime = "2.1"
 shell-words = "1.1"
+crossterm = "0.28"
+ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.59", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Console",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ humantime = "2.1"
 shell-words = "1.1"
 crossterm = "0.28"
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
+unicode-segmentation = "1.12"
+unicode-width = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/README.md
+++ b/README.md
@@ -228,19 +228,20 @@ them for generated paths that would otherwise create feedback loops.
 
 ## Development services
 
-`aster dev` runs a configured set of long-lived targets in one supervised
+`aster services up` runs a configured set of long-lived targets in one supervised
 dashboard:
 
 ```console
-aster dev
-aster dev api web
-aster dev --no-ui
-aster dev --dry-run
+aster services up
+aster services up api web
+aster services up --no-ui
+aster services up --dry-run
 ```
 
-If a project already has a target named `dev`, run that target explicitly with
-`aster target dev <project selectors>`. The same escape hatch works for any
-target name that conflicts with a built-in Aster command.
+Targets named `dev` remain ordinary targets (`aster dev <project selectors>`).
+If a project has a target named `services`, run it explicitly with
+`aster target services <project selectors>`. The same escape hatch works for
+any target name that conflicts with a built-in Aster command.
 
 Services are mappings to ordinary `stream = true` targets. Their non-stream
 target dependencies are pre-start steps: Aster runs them before the service

--- a/README.md
+++ b/README.md
@@ -248,6 +248,15 @@ target dependencies are pre-start steps: Aster runs them before the service
 starts and again before a dependency-triggered or manual restart. The same
 transitive target graph determines which project directories are watched.
 
+The dashboard uses scalable colored service tabs beside one focused log
+stream. Use `h`/`l` or click a tab to switch services, drag the divider or use
+`[`/`]` to resize, and scroll the service list independently when it exceeds
+the terminal height. It also supports fullscreen logs (`f`), wrapping (`w`),
+search (`/`), mouse line selection and clipboard copy (`y`), browser opening
+(`o` or `[open]`), manual restart (`r`), and the `?` controls overlay. Press
+`m` to disable dashboard mouse capture when native terminal selection is
+preferred.
+
 Configure the harness in the workspace-root `aster.toml`:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -226,6 +226,89 @@ Built-in ignores cover common VCS, dependency, and build-output directories.
 During the cooldown window, only configured `suppress_paths` are dropped; use
 them for generated paths that would otherwise create feedback loops.
 
+## Development services
+
+`aster dev` runs a configured set of long-lived targets in one supervised
+dashboard:
+
+```console
+aster dev
+aster dev api web
+aster dev --no-ui
+aster dev --dry-run
+```
+
+If a project already has a target named `dev`, run that target explicitly with
+`aster target dev <project selectors>`. The same escape hatch works for any
+target name that conflicts with a built-in Aster command.
+
+Services are mappings to ordinary `stream = true` targets. Their non-stream
+target dependencies are pre-start steps: Aster runs them before the service
+starts and again before a dependency-triggered or manual restart. The same
+transitive target graph determines which project directories are watched.
+
+Configure the harness in the workspace-root `aster.toml`:
+
+```toml
+[dev]
+port_env_files = [".env", ".env.local"]
+control_port = "control"
+
+[dev.ports.api]
+env = "API_PORT"
+file_env = "PORT"
+default = 4000
+
+[dev.ports.web]
+env = "WEB_PORT"
+default = 3000
+offset_from = "api"
+offset_base = 4000
+saturating_offset = true
+
+[dev.ports.control]
+env = "CONTROL_PORT"
+default = 5000
+
+[dev.services.api]
+target = "//services/api:dev"
+port = "api"
+open_path = "/health"
+env_files = ["services/api/.env"]
+env = { PORT = "{port}", WEB_PORT = "{ports.web}" }
+inherit_env = ["GOOGLE_CLOUD_MODE"]
+order = 10
+
+[dev.services.web]
+target = "//services/web:dev"
+port = "web"
+env = { PORT = "{port}", API_URL = "http://localhost:{ports.api}" }
+order = 20
+```
+
+`port_env_files` participate only in named-port resolution. A service receives
+only a small process baseline (`PATH`, home/user, temporary-directory, locale,
+shell, and terminal variables), its own `env_files`, explicit `env`,
+`ASTER_SERVICE_NAME`, and (when it has a port) `ASTER_SERVICE_PORT`; leading
+target-command environment assignments take final precedence. Other ambient
+variables are intentionally not inherited unless their names appear in that
+service's `inherit_env` allowlist. Process environment values named by a port's
+`env` field take precedence over `file_env` values from those files. When
+`file_env` is omitted, the `env` names are also checked in the files. An
+`offset_from` port adds the positive delta from `offset_base`, which is useful
+for collision-free worktree stacks. By default, a source below the baseline is
+an error; `saturating_offset = true` clamps that delta to zero.
+
+`{port}` and `{ports.<name>}` are expanded in service target commands and
+service environment values. They are separate from the `{files}` target
+capability. `open_path` controls the dashboard's browser URL.
+
+When `control_port` is configured, Aster accepts the platform launcher's
+line-delimited JSON commands on localhost: `status`, `list_services`,
+`restart` (with a `service` field), `restart_all`, and `shutdown`. Aster prints
+the path to a per-run token file; state-changing requests must include its
+contents as the JSON `token` field. Read-only requests do not require it.
+
 ## Contributing and security
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and pull-request

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -235,8 +235,30 @@ pub enum Commands {
         lang: Vec<String>,
     },
 
-    /// Run configured local development services in a supervised dashboard
-    Dev {
+    /// Manage configured local development services
+    Services {
+        #[command(subcommand)]
+        command: ServicesCommands,
+    },
+
+    /// Run a target whose name conflicts with a built-in command
+    #[command(name = "target")]
+    RunTarget {
+        /// Target name followed by normal target selectors and flags
+        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
+    /// Run a single target on projects (catch-all for targets like test, build, lint)
+    #[command(external_subcommand)]
+    ExternalTarget(Vec<String>),
+}
+
+/// Local development service commands
+#[derive(Subcommand)]
+pub enum ServicesCommands {
+    /// Start configured services in a supervised dashboard
+    Up {
         /// Service names from `[dev.services]` (defaults to all services)
         services: Vec<String>,
 
@@ -252,18 +274,6 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
-
-    /// Run a target whose name conflicts with a built-in command
-    #[command(name = "target")]
-    RunTarget {
-        /// Target name followed by normal target selectors and flags
-        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
-        args: Vec<String>,
-    },
-
-    /// Run a single target on projects (catch-all for targets like test, build, lint)
-    #[command(external_subcommand)]
-    ExternalTarget(Vec<String>),
 }
 
 /// Cache subcommands

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -33,6 +33,8 @@ use super::output::OutputMode;
     --warnings-as-errors  Treat warnings as errors (for supported targets)
     --lang <langs>        Filter by language (e.g., --lang nodejs,python)
 
+  Use `aster target <name>` when a target name conflicts with a built-in command.
+
 EXAMPLES:
     aster test --all                     # Test everything
     aster test //...                     # Same as above
@@ -43,6 +45,7 @@ EXAMPLES:
     aster test //... -//vendor/...       # Test all except vendor projects
     aster build //app --dependents       # Build app and everything that uses it
     aster affected test --base=main      # Test projects changed since main
+    aster target dev //services/api      # Run a target named "dev"
 
 HETEROGENEOUS RUNS:
     aster run //a:test //b:build //c:lint   # Run different targets on different projects
@@ -232,9 +235,35 @@ pub enum Commands {
         lang: Vec<String>,
     },
 
+    /// Run configured local development services in a supervised dashboard
+    Dev {
+        /// Service names from `[dev.services]` (defaults to all services)
+        services: Vec<String>,
+
+        /// Disable dependency-aware file watching and automatic restarts
+        #[arg(long)]
+        no_watch: bool,
+
+        /// Use line-oriented logs instead of the interactive dashboard
+        #[arg(long)]
+        no_ui: bool,
+
+        /// Resolve and validate the service plan without starting processes
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Run a target whose name conflicts with a built-in command
+    #[command(name = "target")]
+    RunTarget {
+        /// Target name followed by normal target selectors and flags
+        #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
+
     /// Run a single target on projects (catch-all for targets like test, build, lint)
     #[command(external_subcommand)]
-    Target(Vec<String>),
+    ExternalTarget(Vec<String>),
 }
 
 /// Cache subcommands

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,7 +6,7 @@ pub mod commands;
 pub mod output;
 pub mod run;
 
-pub use commands::{CacheCommands, Cli, Commands, ProjectCommands};
+pub use commands::{CacheCommands, Cli, Commands, ProjectCommands, ServicesCommands};
 pub use output::{
     build_execution_output, output_json, print_summary, ExecutionOutput, ExecutionSummary,
     GraphOutput, OutputMode, ProjectInfo, TargetResult, WhyOutput,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,5 +6,6 @@ pub use project::{
     TargetConfig,
 };
 pub use workspace::{
-    find_workspace_root, AffectedWorkspaceConfig, WatchWorkspaceConfig, WorkspaceConfig,
+    find_workspace_root, AffectedWorkspaceConfig, DevPortConfig, DevServiceConfig,
+    DevWorkspaceConfig, ResolvedDevPortConfig, WatchWorkspaceConfig, WorkspaceConfig,
 };

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -39,6 +39,8 @@ pub struct AsterToml {
     pub watch: WatchWorkspaceConfig,
     #[serde(default)]
     pub affected: AffectedWorkspaceConfig,
+    #[serde(default)]
+    pub dev: super::workspace::DevWorkspaceConfig,
 }
 
 /// Alias target configuration - references another target in the same project

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -34,7 +34,7 @@ pub struct WorkspaceConfig {
     pub targets: HashMap<String, TargetConfig>,
 }
 
-/// Configuration for `aster dev`.
+/// Configuration for `aster services up`.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DevWorkspaceConfig {
@@ -86,7 +86,7 @@ pub struct ResolvedDevPortConfig {
     pub saturating_offset: bool,
 }
 
-/// One long-running service managed by `aster dev`.
+/// One long-running service managed by `aster services up`.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DevServiceConfig {

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -21,6 +21,10 @@ pub struct WorkspaceConfig {
     #[serde(default)]
     pub affected: AffectedWorkspaceConfig,
 
+    /// Local development service harness configuration
+    #[serde(default)]
+    pub dev: DevWorkspaceConfig,
+
     /// Project settings are accepted because a project at the repository root
     /// may share this file with workspace configuration.
     pub name: Option<String>,
@@ -28,6 +32,108 @@ pub struct WorkspaceConfig {
     pub depends_on: Vec<String>,
     #[serde(default)]
     pub targets: HashMap<String, TargetConfig>,
+}
+
+/// Configuration for `aster dev`.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DevWorkspaceConfig {
+    /// Environment files consulted when resolving named ports. Later files win.
+    #[serde(default)]
+    pub port_env_files: Vec<String>,
+
+    /// Named ports shared by services and their environment.
+    #[serde(default)]
+    pub ports: HashMap<String, DevPortConfig>,
+
+    /// Optional named port for the line-delimited JSON control socket.
+    pub control_port: Option<String>,
+
+    /// Named service-to-target mappings.
+    #[serde(default)]
+    pub services: HashMap<String, DevServiceConfig>,
+}
+
+/// A named port used by one or more development services.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum DevPortConfig {
+    /// A fixed port.
+    Fixed(u16),
+    /// A port resolved from the process environment, port env files, or a default.
+    Resolved(ResolvedDevPortConfig),
+}
+
+/// Detailed named-port resolution.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ResolvedDevPortConfig {
+    /// Process environment variables checked in order.
+    #[serde(default, deserialize_with = "deserialize_one_or_many")]
+    pub env: Vec<String>,
+    /// Port-env-file variables checked in order after the process environment.
+    /// When omitted, `env` names are also checked in the configured files.
+    #[serde(default, deserialize_with = "deserialize_optional_one_or_many")]
+    pub file_env: Option<Vec<String>>,
+    /// Default value when no configured environment variable is set.
+    pub default: u16,
+    /// Add the delta between this port and `offset_base` to the default.
+    pub offset_from: Option<String>,
+    /// Baseline for `offset_from`; required when `offset_from` is set.
+    pub offset_base: Option<u16>,
+    /// Clamp a negative offset delta to zero instead of rejecting it.
+    #[serde(default)]
+    pub saturating_offset: bool,
+}
+
+/// One long-running service managed by `aster dev`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DevServiceConfig {
+    /// Address of a `stream = true` target.
+    pub target: String,
+    /// Named port from `[dev.ports]`.
+    pub port: Option<String>,
+    /// Optional browser path appended to `http://localhost:<port>`.
+    pub open_path: Option<String>,
+    /// Environment files loaded into the service process. Later files win.
+    #[serde(default)]
+    pub env_files: Vec<String>,
+    /// Environment overrides. Values support `{port}` and `{ports.<name>}`.
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+    /// Ambient environment variables explicitly allowed into the service.
+    #[serde(default)]
+    pub inherit_env: Vec<String>,
+    /// Stable startup/display order. Ties are sorted by service name.
+    #[serde(default)]
+    pub order: i32,
+}
+
+fn deserialize_one_or_many<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    Ok(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(value) => vec![value],
+        OneOrMany::Many(values) => values,
+    })
+}
+
+fn deserialize_optional_one_or_many<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_one_or_many(deserializer).map(Some)
 }
 
 /// Configuration controlling which Git changes participate in affected analysis.
@@ -123,6 +229,61 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    #[test]
+    fn parses_dev_services_ports_and_environment() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("aster.toml"),
+            r#"
+[dev]
+port_env_files = [".env"]
+control_port = "api"
+
+[dev.ports.api]
+env = "API_PORT"
+file_env = "PORT"
+default = 4000
+
+[dev.ports.web]
+env = "WEB_PORT"
+default = 3000
+offset_from = "api"
+offset_base = 4000
+
+[dev.services.api]
+target = "//api:dev"
+port = "api"
+open_path = "/health"
+env_files = ["api/.env"]
+env = { PORT = "{port}", WEB_PORT = "{ports.web}" }
+inherit_env = ["GOOGLE_CLOUD_MODE"]
+order = 10
+"#,
+        )
+        .unwrap();
+
+        let config = WorkspaceConfig::load(temp.path()).unwrap();
+        assert_eq!(config.dev.services["api"].target, "//api:dev");
+        assert_eq!(
+            config.dev.services["api"].open_path.as_deref(),
+            Some("/health")
+        );
+        assert_eq!(
+            config.dev.services["api"].inherit_env,
+            ["GOOGLE_CLOUD_MODE"]
+        );
+        let DevPortConfig::Resolved(api) = &config.dev.ports["api"] else {
+            panic!("expected resolved port");
+        };
+        assert_eq!(api.env, ["API_PORT"]);
+        assert_eq!(api.file_env.as_deref().unwrap(), ["PORT"]);
+        let DevPortConfig::Resolved(web) = &config.dev.ports["web"] else {
+            panic!("expected resolved port");
+        };
+        assert_eq!(web.offset_from.as_deref(), Some("api"));
+        assert_eq!(web.offset_base, Some(4000));
+    }
 
     #[test]
     fn test_find_workspace_root_with_aster_toml() {

--- a/src/dev/dashboard.rs
+++ b/src/dev/dashboard.rs
@@ -1,0 +1,416 @@
+use std::collections::{HashMap, VecDeque};
+use std::io;
+
+use anyhow::Result;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal::{
+    disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+};
+use crossterm::{execute, ExecutableCommand};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::Terminal;
+
+use super::plan::ServicePlan;
+use super::process::LogEvent;
+
+const MAX_LINES: usize = 5000;
+const MAX_LOG_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug)]
+pub enum ServiceState {
+    Starting,
+    Running,
+    Restarting,
+    Stopped,
+}
+
+impl ServiceState {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Running => "running",
+            Self::Restarting => "restarting",
+            Self::Stopped => "stopped",
+        }
+    }
+}
+
+pub struct Dashboard {
+    services: Vec<String>,
+    ports: HashMap<String, Option<u16>>,
+    urls: HashMap<String, Option<String>>,
+    states: HashMap<String, ServiceState>,
+    logs: HashMap<String, VecDeque<Line<'static>>>,
+    log_bytes: HashMap<String, usize>,
+    active: usize,
+    scroll: u16,
+    max_scroll: u16,
+    wrap: bool,
+    fullscreen: bool,
+}
+
+impl Dashboard {
+    pub fn new(services: &[ServicePlan]) -> Self {
+        Self {
+            services: services
+                .iter()
+                .map(|service| service.name.clone())
+                .collect(),
+            ports: services
+                .iter()
+                .map(|service| (service.name.clone(), service.port))
+                .collect(),
+            urls: services
+                .iter()
+                .map(|service| (service.name.clone(), service.open_url.clone()))
+                .collect(),
+            states: services
+                .iter()
+                .map(|service| (service.name.clone(), ServiceState::Stopped))
+                .collect(),
+            logs: services
+                .iter()
+                .map(|service| (service.name.clone(), VecDeque::new()))
+                .collect(),
+            log_bytes: services
+                .iter()
+                .map(|service| (service.name.clone(), 0))
+                .collect(),
+            active: 0,
+            scroll: u16::MAX,
+            max_scroll: 0,
+            wrap: true,
+            fullscreen: false,
+        }
+    }
+
+    pub fn active_name(&self) -> &str {
+        &self.services[self.active]
+    }
+
+    pub fn active_url(&self) -> Option<&str> {
+        self.urls.get(self.active_name()).and_then(Option::as_deref)
+    }
+
+    pub fn set_state(&mut self, service: &str, state: ServiceState) {
+        self.states.insert(service.to_string(), state);
+    }
+
+    pub fn push_log(&mut self, event: LogEvent) {
+        let style = if event.stderr {
+            Style::default().fg(Color::Red)
+        } else {
+            Style::default()
+        };
+        self.push_styled(&event.service, event.line, style);
+    }
+
+    pub fn push_system(&mut self, service: &str, line: impl Into<String>) {
+        self.push_styled(service, line.into(), Style::default().fg(Color::Cyan));
+    }
+
+    fn push_styled(&mut self, service: &str, line: String, style: Style) {
+        let Some(lines) = self.logs.get_mut(service) else {
+            return;
+        };
+        let line = strip_ansi_sequences(&line);
+        let bytes = self.log_bytes.entry(service.to_string()).or_default();
+        *bytes = bytes.saturating_add(line.len());
+        lines.push_back(Line::styled(line, style));
+        while lines.len() > MAX_LINES || *bytes > MAX_LOG_BYTES {
+            let Some(removed) = lines.pop_front() else {
+                break;
+            };
+            let removed_bytes = removed
+                .spans
+                .iter()
+                .map(|span| span.content.len())
+                .sum::<usize>();
+            *bytes = bytes.saturating_sub(removed_bytes);
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DashboardAction {
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            return DashboardAction::Quit;
+        }
+        match key.code {
+            KeyCode::Char('q') => DashboardAction::Quit,
+            KeyCode::Char('r') => DashboardAction::Restart(self.active_name().to_string()),
+            KeyCode::Char('o') => DashboardAction::Open,
+            KeyCode::Char('h') | KeyCode::Left => {
+                self.active = self.active.saturating_sub(1);
+                self.scroll = u16::MAX;
+                DashboardAction::Draw
+            }
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
+                self.active = (self.active + 1).min(self.services.len() - 1);
+                self.scroll = u16::MAX;
+                DashboardAction::Draw
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.scroll != u16::MAX {
+                    self.scroll = self.scroll.saturating_add(1).min(self.max_scroll);
+                }
+                DashboardAction::Draw
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.scroll = if self.scroll == u16::MAX {
+                    self.max_scroll.saturating_sub(1)
+                } else {
+                    self.scroll.saturating_sub(1)
+                };
+                DashboardAction::Draw
+            }
+            KeyCode::Char('w') => {
+                self.wrap = !self.wrap;
+                DashboardAction::Draw
+            }
+            KeyCode::Char('f') => {
+                self.fullscreen = !self.fullscreen;
+                DashboardAction::Draw
+            }
+            KeyCode::Enter => {
+                self.scroll = u16::MAX;
+                DashboardAction::Draw
+            }
+            _ => DashboardAction::None,
+        }
+    }
+
+    pub fn draw(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+        workspace: &str,
+        control_token_path: Option<&str>,
+    ) -> Result<()> {
+        let active = self.active_name().to_string();
+        let logs = self.logs.get(&active).cloned().unwrap_or_default();
+        let services = self.services.clone();
+        let states = self.states.clone();
+        let ports = self.ports.clone();
+        let active_index = self.active;
+        let wrap = self.wrap;
+        let fullscreen = self.fullscreen;
+        let scroll = self.scroll;
+        let footer_height = if control_token_path.is_some() { 3 } else { 1 };
+
+        terminal.draw(|frame| {
+            let outer = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(1),
+                    Constraint::Min(4),
+                    Constraint::Length(footer_height),
+                ])
+                .split(frame.area());
+            frame.render_widget(
+                Paragraph::new(workspace).style(Style::default().fg(Color::DarkGray)),
+                outer[0],
+            );
+            let body = if fullscreen {
+                vec![outer[1]]
+            } else {
+                Layout::default()
+                    .direction(Direction::Horizontal)
+                    .constraints([Constraint::Length(32), Constraint::Min(30)])
+                    .split(outer[1])
+                    .to_vec()
+            };
+
+            if !fullscreen {
+                let items = services.iter().enumerate().map(|(index, name)| {
+                    let state = states.get(name).copied().unwrap_or(ServiceState::Stopped);
+                    let port = ports
+                        .get(name)
+                        .copied()
+                        .flatten()
+                        .map(|port| format!(" :{port}"))
+                        .unwrap_or_default();
+                    let style = if index == active_index {
+                        Style::default()
+                            .fg(Color::Cyan)
+                            .add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    };
+                    ListItem::new(Line::from(vec![
+                        Span::styled(format!("{name}{port}"), style),
+                        Span::styled(
+                            format!("  {}", state.label()),
+                            Style::default().fg(Color::DarkGray),
+                        ),
+                    ]))
+                });
+                frame.render_widget(
+                    List::new(items).block(Block::default().borders(Borders::ALL).title("services")),
+                    body[0],
+                );
+            }
+
+            let log_area = *body.last().expect("body always has a log area");
+            let height = log_area.height.saturating_sub(2) as usize;
+            let log_lines = logs.into_iter().collect::<Vec<_>>();
+            let rendered_height = if wrap {
+                Paragraph::new(log_lines.clone())
+                    .wrap(Wrap { trim: false })
+                    .line_count(log_area.width.saturating_sub(2))
+            } else {
+                log_lines.len()
+            };
+            let max_scroll =
+                u16::try_from(rendered_height.saturating_sub(height)).unwrap_or(u16::MAX);
+            self.max_scroll = max_scroll;
+            let scroll = if scroll == u16::MAX {
+                max_scroll
+            } else {
+                let clamped = scroll.min(max_scroll);
+                self.scroll = clamped;
+                clamped
+            };
+            let paragraph = Paragraph::new(log_lines)
+                .block(Block::default().borders(Borders::ALL).title(active))
+                .scroll((scroll, 0));
+            let paragraph = if wrap {
+                paragraph.wrap(Wrap { trim: false })
+            } else {
+                paragraph
+            };
+            frame.render_widget(paragraph, log_area);
+            let help =
+                "h/l service  j/k scroll  Enter bottom  r restart  o open  w wrap  f fullscreen  q quit";
+            let footer = control_token_path
+                .map(|path| format!("control token: {path}\n{help}"))
+                .unwrap_or_else(|| help.to_string());
+            frame.render_widget(
+                Paragraph::new(footer)
+                    .wrap(Wrap { trim: false })
+                    .style(Style::default().fg(Color::DarkGray)),
+                outer[2],
+            );
+        })?;
+        Ok(())
+    }
+}
+
+fn strip_ansi_sequences(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] != 0x1b {
+            output.push(bytes[index]);
+            index += 1;
+            continue;
+        }
+
+        index += 1;
+        let Some(&kind) = bytes.get(index) else {
+            break;
+        };
+        // ESC can be followed by ordinary UTF-8 in malformed service output.
+        // Leave the complete non-ASCII code point for the normal copy path.
+        if !kind.is_ascii() {
+            continue;
+        }
+        index += 1;
+        match kind {
+            // Control Sequence Introducer: consume through its final byte.
+            b'[' => {
+                while let Some(&byte) = bytes.get(index) {
+                    index += 1;
+                    if (0x40..=0x7e).contains(&byte) {
+                        break;
+                    }
+                }
+            }
+            // Operating System Command: terminated by BEL or String Terminator.
+            b']' => {
+                while let Some(&byte) = bytes.get(index) {
+                    index += 1;
+                    if byte == 0x07 {
+                        break;
+                    }
+                    if byte == 0x1b && bytes.get(index) == Some(&b'\\') {
+                        index += 1;
+                        break;
+                    }
+                }
+            }
+            // DCS, SOS, PM, and APC strings are terminated by ESC backslash.
+            b'P' | b'X' | b'^' | b'_' => {
+                while let Some(&byte) = bytes.get(index) {
+                    index += 1;
+                    if byte == 0x1b && bytes.get(index) == Some(&b'\\') {
+                        index += 1;
+                        break;
+                    }
+                }
+            }
+            // Other escape sequences are two bytes long.
+            _ => {}
+        }
+    }
+    String::from_utf8(output).expect("removing ASCII escape sequences preserves UTF-8")
+}
+
+pub enum DashboardAction {
+    None,
+    Draw,
+    Restart(String),
+    Open,
+    Quit,
+}
+
+pub struct TerminalGuard {
+    pub terminal: Terminal<CrosstermBackend<io::Stdout>>,
+}
+
+impl TerminalGuard {
+    pub fn enter() -> Result<Self> {
+        enable_raw_mode()?;
+        let mut stdout = io::stdout();
+        if let Err(error) = stdout.execute(EnterAlternateScreen) {
+            let _ = disable_raw_mode();
+            return Err(error.into());
+        }
+        let terminal = match Terminal::new(CrosstermBackend::new(stdout)) {
+            Ok(terminal) => terminal,
+            Err(error) => {
+                let _ = execute!(io::stdout(), LeaveAlternateScreen);
+                let _ = disable_raw_mode();
+                return Err(error.into());
+            }
+        };
+        Ok(Self { terminal })
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        let _ = self.terminal.show_cursor();
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_ansi_sequences;
+
+    #[test]
+    fn strips_terminal_control_sequences_from_service_logs() {
+        assert_eq!(
+            strip_ansi_sequences(
+                "\u{1b}[31mred\u{1b}[0m plain \u{1b}]0;title\u{7}text \u{1b}[2Kdone"
+            ),
+            "red plain text done"
+        );
+        assert_eq!(strip_ansi_sequences("unicode 🦀 stays"), "unicode 🦀 stays");
+        assert_eq!(strip_ansi_sequences("\u{1b}é"), "é");
+    }
+}

--- a/src/dev/dashboard.rs
+++ b/src/dev/dashboard.rs
@@ -1,24 +1,48 @@
-use std::collections::{HashMap, VecDeque};
-use std::io;
+use std::collections::VecDeque;
+use std::io::{self, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
 
-use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use anyhow::{anyhow, Context, Result};
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, KeyCode, KeyEvent, KeyModifiers, MouseButton,
+    MouseEvent, MouseEventKind,
+};
+use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
-use crossterm::{execute, ExecutableCommand};
 use ratatui::backend::CrosstermBackend;
-use ratatui::layout::{Constraint, Direction, Layout};
+use ratatui::layout::{Alignment, Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
 use ratatui::Terminal;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 use super::plan::ServicePlan;
 use super::process::LogEvent;
 
 const MAX_LINES: usize = 5000;
 const MAX_LOG_BYTES: usize = 2 * 1024 * 1024;
+const DEFAULT_SERVICE_LIST_WIDTH: u16 = 38;
+const MIN_SERVICE_LIST_WIDTH: u16 = 30;
+const MIN_LOG_PANEL_WIDTH: u16 = 28;
+const DIVIDER_WIDTH: u16 = 1;
+const DIVIDER_RESIZE_STEP: i16 = 2;
+const SERVICE_LIST_HEADER_ROWS: u16 = 2;
+const SERVICE_TAB_ROWS: u16 = 3;
+const OPEN_LINK_LABEL: &str = "[open]";
+const COPY_FLASH_DURATION: Duration = Duration::from_millis(350);
+const SERVICE_COLORS: [Color; 6] = [
+    Color::Cyan,
+    Color::Magenta,
+    Color::Green,
+    Color::LightCyan,
+    Color::Yellow,
+    Color::Blue,
+];
 
 #[derive(Clone, Copy, Debug)]
 pub enum ServiceState {
@@ -39,72 +63,268 @@ impl ServiceState {
     }
 }
 
+#[derive(Clone)]
+struct LogLine {
+    text: String,
+    style: Style,
+}
+
+struct ServicePane {
+    name: String,
+    port: Option<u16>,
+    url: Option<String>,
+    color: Color,
+    state: ServiceState,
+    lines: VecDeque<LogLine>,
+    log_bytes: usize,
+    wrap_cache: Option<WrapRowCache>,
+    scroll_top: usize,
+    last_view_height: usize,
+    last_view_width: usize,
+}
+
+struct WrapRowCache {
+    width: usize,
+    rows: VecDeque<usize>,
+    total_rows: usize,
+}
+
+impl ServicePane {
+    fn ensure_wrap_cache(&mut self) {
+        let width = self.last_view_width.max(1);
+        if self
+            .wrap_cache
+            .as_ref()
+            .is_some_and(|cache| cache.width == width && cache.rows.len() == self.lines.len())
+        {
+            return;
+        }
+        let rows = self
+            .lines
+            .iter()
+            .map(|line| Self::visual_rows(&line.text, width))
+            .collect::<VecDeque<_>>();
+        let total_rows = rows.iter().sum();
+        self.wrap_cache = Some(WrapRowCache {
+            width,
+            rows,
+            total_rows,
+        });
+    }
+
+    fn visual_rows(text: &str, width: usize) -> usize {
+        if width == 0 {
+            return 1;
+        }
+        let line = Line::from(text.to_string());
+        wrapped_line_rows(&line, width, 0, usize::MAX).len().max(1)
+    }
+
+    fn line_position_at_visual_offset(&mut self, visual_offset: usize) -> Option<(usize, usize)> {
+        if self.lines.is_empty() {
+            return None;
+        }
+        self.ensure_wrap_cache();
+        let cache = self.wrap_cache.as_ref()?;
+        let mut cumulative = 0;
+        for (index, rows) in cache.rows.iter().copied().enumerate() {
+            if cumulative + rows > visual_offset {
+                return Some((index, visual_offset.saturating_sub(cumulative)));
+            }
+            cumulative += rows;
+        }
+        let rows = cache.rows.back().copied().unwrap_or(1);
+        Some((self.lines.len() - 1, rows.saturating_sub(1)))
+    }
+
+    fn visual_offset_for_line(&mut self, line_index: usize) -> usize {
+        self.ensure_wrap_cache();
+        self.wrap_cache
+            .as_ref()
+            .map(|cache| cache.rows.iter().take(line_index).sum())
+            .unwrap_or(0)
+    }
+
+    fn max_scroll_top(&mut self, wrap: bool) -> usize {
+        if wrap {
+            self.ensure_wrap_cache();
+            self.wrap_cache
+                .as_ref()
+                .map(|cache| cache.total_rows.saturating_sub(self.last_view_height))
+                .unwrap_or(0)
+        } else {
+            self.lines.len().saturating_sub(self.last_view_height)
+        }
+    }
+
+    fn resolved_scroll_top(&mut self, wrap: bool) -> usize {
+        if self.scroll_top == usize::MAX {
+            self.max_scroll_top(wrap)
+        } else {
+            self.scroll_top.min(self.max_scroll_top(wrap))
+        }
+    }
+
+    fn scroll_lines(&mut self, delta: isize, wrap: bool) {
+        let current = self.resolved_scroll_top(wrap);
+        self.scroll_top = if delta.is_negative() {
+            current.saturating_sub(delta.unsigned_abs())
+        } else {
+            current
+                .saturating_add(delta as usize)
+                .min(self.max_scroll_top(wrap))
+        };
+    }
+
+    fn scroll_page(&mut self, direction: isize, half: bool, wrap: bool) {
+        let amount = if half {
+            (self.last_view_height / 2).max(1)
+        } else {
+            self.last_view_height.max(1)
+        };
+        self.scroll_lines(direction.saturating_mul(amount as isize), wrap);
+    }
+
+    fn scroll_to_bottom(&mut self) {
+        self.scroll_top = usize::MAX;
+    }
+
+    fn push(&mut self, line: String, style: Style, wrap: bool) {
+        let following = self.scroll_top == usize::MAX
+            || self.scroll_top >= self.max_scroll_top(wrap).saturating_sub(1);
+        self.log_bytes = self.log_bytes.saturating_add(line.len());
+        self.lines.push_back(LogLine { text: line, style });
+        self.wrap_cache = None;
+        while self.lines.len() > MAX_LINES || self.log_bytes > MAX_LOG_BYTES {
+            let Some(removed) = self.lines.pop_front() else {
+                break;
+            };
+            self.log_bytes = self.log_bytes.saturating_sub(removed.text.len());
+            if self.scroll_top != usize::MAX {
+                let removed_rows = if wrap {
+                    Self::visual_rows(&removed.text, self.last_view_width.max(1))
+                } else {
+                    1
+                };
+                self.scroll_top = self.scroll_top.saturating_sub(removed_rows);
+            }
+        }
+        if following {
+            self.scroll_top = usize::MAX;
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InputMode {
+    Normal,
+    Search,
+}
+
 pub struct Dashboard {
-    services: Vec<String>,
-    ports: HashMap<String, Option<u16>>,
-    urls: HashMap<String, Option<String>>,
-    states: HashMap<String, ServiceState>,
-    logs: HashMap<String, VecDeque<Line<'static>>>,
-    log_bytes: HashMap<String, usize>,
+    panes: Vec<ServicePane>,
     active: usize,
-    scroll: u16,
-    max_scroll: u16,
     wrap: bool,
     fullscreen: bool,
+    show_help: bool,
+    input_mode: InputMode,
+    search_input: String,
+    search_hits: Vec<usize>,
+    search_cursor: usize,
+    status: String,
+    service_list_width: u16,
+    service_list_scroll: usize,
+    service_list_manual_scroll: bool,
+    service_list_view_height: usize,
+    last_workspace_width: u16,
+    divider_dragging: bool,
+    mouse_enabled: bool,
+    selection_anchor: Option<(usize, usize)>,
+    selection_range: Option<(usize, usize, usize)>,
+    selection_dragging: bool,
+    copied_flash_range: Option<(usize, usize, usize)>,
+    copied_flash_until: Option<Instant>,
 }
 
 impl Dashboard {
     pub fn new(services: &[ServicePlan]) -> Self {
+        Self::from_specs(
+            services
+                .iter()
+                .map(|service| (service.name.clone(), service.port, service.open_url.clone()))
+                .collect(),
+        )
+    }
+
+    fn from_specs(services: Vec<(String, Option<u16>, Option<String>)>) -> Self {
         Self {
-            services: services
-                .iter()
-                .map(|service| service.name.clone())
-                .collect(),
-            ports: services
-                .iter()
-                .map(|service| (service.name.clone(), service.port))
-                .collect(),
-            urls: services
-                .iter()
-                .map(|service| (service.name.clone(), service.open_url.clone()))
-                .collect(),
-            states: services
-                .iter()
-                .map(|service| (service.name.clone(), ServiceState::Stopped))
-                .collect(),
-            logs: services
-                .iter()
-                .map(|service| (service.name.clone(), VecDeque::new()))
-                .collect(),
-            log_bytes: services
-                .iter()
-                .map(|service| (service.name.clone(), 0))
+            panes: services
+                .into_iter()
+                .enumerate()
+                .map(|(index, (name, port, url))| ServicePane {
+                    name,
+                    port,
+                    url,
+                    color: SERVICE_COLORS[index % SERVICE_COLORS.len()],
+                    state: ServiceState::Stopped,
+                    lines: VecDeque::new(),
+                    log_bytes: 0,
+                    wrap_cache: None,
+                    scroll_top: usize::MAX,
+                    last_view_height: 1,
+                    last_view_width: 80,
+                })
                 .collect(),
             active: 0,
-            scroll: u16::MAX,
-            max_scroll: 0,
             wrap: true,
             fullscreen: false,
+            show_help: false,
+            input_mode: InputMode::Normal,
+            search_input: String::new(),
+            search_hits: Vec::new(),
+            search_cursor: 0,
+            status: "ready".to_string(),
+            service_list_width: DEFAULT_SERVICE_LIST_WIDTH,
+            service_list_scroll: 0,
+            service_list_manual_scroll: false,
+            service_list_view_height: 1,
+            last_workspace_width: 120,
+            divider_dragging: false,
+            mouse_enabled: true,
+            selection_anchor: None,
+            selection_range: None,
+            selection_dragging: false,
+            copied_flash_range: None,
+            copied_flash_until: None,
         }
     }
 
     pub fn active_name(&self) -> &str {
-        &self.services[self.active]
+        &self.panes[self.active].name
     }
 
     pub fn active_url(&self) -> Option<&str> {
-        self.urls.get(self.active_name()).and_then(Option::as_deref)
+        self.panes[self.active].url.as_deref()
     }
 
     pub fn set_state(&mut self, service: &str, state: ServiceState) {
-        self.states.insert(service.to_string(), state);
+        if let Some(pane) = self.panes.iter_mut().find(|pane| pane.name == service) {
+            pane.state = state;
+        }
     }
 
     pub fn push_log(&mut self, event: LogEvent) {
         let style = if event.stderr {
-            Style::default().fg(Color::Red)
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
         } else {
-            Style::default()
+            let lowercase = event.line.to_ascii_lowercase();
+            if lowercase.contains("error") {
+                Style::default().fg(Color::Red)
+            } else if lowercase.contains("warn") {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            }
         };
         self.push_styled(&event.service, event.line, style);
     }
@@ -114,71 +334,473 @@ impl Dashboard {
     }
 
     fn push_styled(&mut self, service: &str, line: String, style: Style) {
-        let Some(lines) = self.logs.get_mut(service) else {
-            return;
-        };
-        let line = strip_ansi_sequences(&line);
-        let bytes = self.log_bytes.entry(service.to_string()).or_default();
-        *bytes = bytes.saturating_add(line.len());
-        lines.push_back(Line::styled(line, style));
-        while lines.len() > MAX_LINES || *bytes > MAX_LOG_BYTES {
-            let Some(removed) = lines.pop_front() else {
-                break;
-            };
-            let removed_bytes = removed
-                .spans
-                .iter()
-                .map(|span| span.content.len())
-                .sum::<usize>();
-            *bytes = bytes.saturating_sub(removed_bytes);
+        let wrap = self.wrap;
+        if let Some(pane) = self.panes.iter_mut().find(|pane| pane.name == service) {
+            pane.push(strip_ansi_sequences(&line), style, wrap);
         }
     }
 
-    pub fn handle_key(&mut self, key: KeyEvent) -> DashboardAction {
-        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
-            return DashboardAction::Quit;
+    fn set_active(&mut self, index: usize) {
+        if index >= self.panes.len() {
+            return;
         }
-        match key.code {
-            KeyCode::Char('q') => DashboardAction::Quit,
-            KeyCode::Char('r') => DashboardAction::Restart(self.active_name().to_string()),
-            KeyCode::Char('o') => DashboardAction::Open,
-            KeyCode::Char('h') | KeyCode::Left => {
-                self.active = self.active.saturating_sub(1);
-                self.scroll = u16::MAX;
-                DashboardAction::Draw
-            }
-            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
-                self.active = (self.active + 1).min(self.services.len() - 1);
-                self.scroll = u16::MAX;
-                DashboardAction::Draw
-            }
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.scroll != u16::MAX {
-                    self.scroll = self.scroll.saturating_add(1).min(self.max_scroll);
-                }
-                DashboardAction::Draw
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.scroll = if self.scroll == u16::MAX {
-                    self.max_scroll.saturating_sub(1)
+        self.active = index;
+        self.service_list_manual_scroll = false;
+        self.clear_selection();
+        if self.input_mode == InputMode::Search {
+            self.refresh_search();
+        }
+        self.status = format!("active service: {}", self.active_name());
+    }
+
+    fn active_pane_mut(&mut self) -> &mut ServicePane {
+        &mut self.panes[self.active]
+    }
+
+    fn root_layout(&self, area: Rect, control_token_path: Option<&str>) -> Vec<Rect> {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Min(3),
+                Constraint::Length(1),
+                Constraint::Length(if self.input_mode == InputMode::Search {
+                    1
                 } else {
-                    self.scroll.saturating_sub(1)
-                };
-                DashboardAction::Draw
+                    0
+                }),
+                Constraint::Length(u16::from(control_token_path.is_some())),
+            ])
+            .split(area)
+            .to_vec()
+    }
+
+    fn workspace_layout(
+        &self,
+        area: Rect,
+        control_token_path: Option<&str>,
+    ) -> (Option<Rect>, Option<Rect>, Rect) {
+        let workspace = self.root_layout(area, control_token_path)[1];
+        if self.fullscreen {
+            return (None, None, workspace);
+        }
+        let list_width = self.clamp_service_list_width(self.service_list_width, workspace.width);
+        let columns = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(list_width),
+                Constraint::Length(DIVIDER_WIDTH),
+                Constraint::Min(1),
+            ])
+            .split(workspace);
+        (Some(columns[0]), Some(columns[1]), columns[2])
+    }
+
+    fn clamp_service_list_width(&self, requested: u16, total_width: u16) -> u16 {
+        let available = total_width.saturating_sub(DIVIDER_WIDTH);
+        if available <= 2 {
+            return available / 2;
+        }
+        let min_left = MIN_SERVICE_LIST_WIDTH.min(available / 2).max(1);
+        let min_right = MIN_LOG_PANEL_WIDTH
+            .min(available.saturating_sub(min_left))
+            .max(1);
+        requested.clamp(min_left, available.saturating_sub(min_right).max(min_left))
+    }
+
+    fn resize_service_list(&mut self, delta: i16) {
+        let requested = if delta.is_negative() {
+            self.service_list_width.saturating_sub(delta.unsigned_abs())
+        } else {
+            self.service_list_width.saturating_add(delta as u16)
+        };
+        self.service_list_width =
+            self.clamp_service_list_width(requested, self.last_workspace_width);
+        self.status = format!("service list width: {}", self.service_list_width);
+    }
+
+    fn set_service_list_width_from_column(&mut self, column: u16, workspace: Rect) {
+        let requested = column.saturating_sub(workspace.x);
+        self.service_list_width = self.clamp_service_list_width(requested, workspace.width);
+        self.status = format!("service list width: {}", self.service_list_width);
+    }
+
+    fn service_list_body_rect(area: Rect) -> Rect {
+        Rect::new(
+            area.x.saturating_add(1),
+            area.y.saturating_add(SERVICE_LIST_HEADER_ROWS),
+            area.width.saturating_sub(2),
+            area.height.saturating_sub(SERVICE_LIST_HEADER_ROWS),
+        )
+    }
+
+    fn keep_active_service_visible(&mut self) {
+        let visible = self.service_list_view_height.max(1);
+        if self.active < self.service_list_scroll {
+            self.service_list_scroll = self.active;
+        } else if self.active >= self.service_list_scroll.saturating_add(visible) {
+            self.service_list_scroll = self.active.saturating_add(1).saturating_sub(visible);
+        }
+        self.service_list_scroll = self
+            .service_list_scroll
+            .min(self.panes.len().saturating_sub(visible));
+    }
+
+    fn scroll_service_list(&mut self, delta: isize) {
+        let max = self
+            .panes
+            .len()
+            .saturating_sub(self.service_list_view_height.max(1));
+        self.service_list_scroll = if delta.is_negative() {
+            self.service_list_scroll
+                .saturating_sub(delta.unsigned_abs())
+        } else {
+            self.service_list_scroll
+                .saturating_add(delta as usize)
+                .min(max)
+        };
+        self.service_list_manual_scroll = true;
+        self.status = format!(
+            "services {}-{}/{}",
+            self.service_list_scroll.saturating_add(1),
+            self.service_list_scroll
+                .saturating_add(self.service_list_view_height)
+                .min(self.panes.len()),
+            self.panes.len()
+        );
+    }
+
+    fn render_service_list(&mut self, frame: &mut ratatui::Frame<'_>, area: Rect) {
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                "services",
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Rect::new(
+                area.x.saturating_add(1),
+                area.y,
+                area.width.saturating_sub(2),
+                1,
+            ),
+        );
+
+        let inner = Self::service_list_body_rect(area);
+        let visible = (inner.height / SERVICE_TAB_ROWS) as usize;
+        if visible == 0 {
+            return;
+        }
+        self.service_list_view_height = visible;
+        if self.service_list_manual_scroll {
+            self.service_list_scroll = self
+                .service_list_scroll
+                .min(self.panes.len().saturating_sub(visible));
+        } else {
+            self.keep_active_service_visible();
+        }
+
+        let range = if self.panes.len() > visible {
+            format!(
+                "{}-{}/{}",
+                self.service_list_scroll + 1,
+                (self.service_list_scroll + visible).min(self.panes.len()),
+                self.panes.len()
+            )
+        } else {
+            self.panes.len().to_string()
+        };
+        frame.render_widget(
+            Paragraph::new(Span::styled(range, Style::default().fg(Color::DarkGray)))
+                .alignment(Alignment::Right),
+            Rect::new(
+                area.x.saturating_add(1),
+                area.y,
+                area.width.saturating_sub(2),
+                1,
+            ),
+        );
+
+        for (slot, index) in (self.service_list_scroll..self.panes.len())
+            .take(visible)
+            .enumerate()
+        {
+            let pane = &self.panes[index];
+            let selected = index == self.active;
+            let tab_area = Rect::new(
+                inner.x,
+                inner.y + slot as u16 * SERVICE_TAB_ROWS,
+                inner.width,
+                SERVICE_TAB_ROWS,
+            );
+            let row_style = if selected {
+                Style::default()
+                    .bg(Color::Rgb(38, 40, 50))
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            if selected {
+                frame.render_widget(Block::default().style(row_style), tab_area);
             }
-            KeyCode::Char('w') => {
-                self.wrap = !self.wrap;
-                DashboardAction::Draw
+            let title_style = if selected {
+                Style::default()
+                    .fg(Color::White)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::Gray)
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("● ", Style::default().fg(pane.color)),
+                    Span::styled(pane.name.clone(), title_style),
+                ]))
+                .style(row_style),
+                Rect::new(tab_area.x, tab_area.y, tab_area.width, 1),
+            );
+
+            let state_color = match pane.state {
+                ServiceState::Starting | ServiceState::Restarting => Color::Yellow,
+                ServiceState::Running => Color::Green,
+                ServiceState::Stopped => Color::DarkGray,
+            };
+            let mut metadata = vec![
+                Span::raw("  "),
+                Span::styled(pane.state.label(), Style::default().fg(state_color)),
+            ];
+            if let Some(port) = pane.port {
+                metadata.push(Span::styled(
+                    format!("  ·  localhost:{port}"),
+                    Style::default().fg(Color::DarkGray),
+                ));
             }
-            KeyCode::Char('f') => {
-                self.fullscreen = !self.fullscreen;
-                DashboardAction::Draw
+            frame.render_widget(
+                Paragraph::new(Line::from(metadata)).style(row_style),
+                Rect::new(tab_area.x, tab_area.y.saturating_add(1), tab_area.width, 1),
+            );
+
+            if pane.url.is_some() && inner.width >= OPEN_LINK_LABEL.len() as u16 {
+                frame.render_widget(
+                    Paragraph::new(Span::styled(
+                        OPEN_LINK_LABEL,
+                        Style::default()
+                            .fg(Color::Blue)
+                            .add_modifier(Modifier::UNDERLINED | Modifier::BOLD),
+                    ))
+                    .alignment(Alignment::Right)
+                    .style(row_style),
+                    Rect::new(
+                        inner
+                            .x
+                            .saturating_add(inner.width)
+                            .saturating_sub(OPEN_LINK_LABEL.len() as u16),
+                        tab_area.y,
+                        OPEN_LINK_LABEL.len() as u16,
+                        1,
+                    ),
+                );
             }
-            KeyCode::Enter => {
-                self.scroll = u16::MAX;
-                DashboardAction::Draw
+        }
+    }
+
+    fn render(
+        &mut self,
+        frame: &mut ratatui::Frame<'_>,
+        workspace: &str,
+        control_token_path: Option<&str>,
+    ) {
+        self.clear_copy_flash_if_expired();
+        let root = self.root_layout(frame.area(), control_token_path);
+        self.last_workspace_width = root[1].width;
+
+        let header = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(70), Constraint::Percentage(30)])
+            .split(root[0]);
+        frame.render_widget(
+            Paragraph::new(workspace.to_string()).style(Style::default().fg(Color::Gray)),
+            header[0],
+        );
+        frame.render_widget(
+            Paragraph::new(self.status.as_str())
+                .alignment(Alignment::Right)
+                .style(Style::default().fg(Color::DarkGray)),
+            header[1],
+        );
+
+        let (service_list, divider, logs) = self.workspace_layout(frame.area(), control_token_path);
+        if let Some(service_list) = service_list {
+            self.render_service_list(frame, service_list);
+        }
+        if let Some(divider) = divider {
+            let style = if self.divider_dragging {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default().fg(Color::DarkGray)
+            };
+            frame.render_widget(
+                Paragraph::new(
+                    (0..divider.height)
+                        .map(|_| Line::from(Span::styled("│", style)))
+                        .collect::<Vec<_>>(),
+                ),
+                divider,
+            );
+        }
+
+        let active = self.active;
+        let search_query = if self.input_mode == InputMode::Search {
+            let query = self.search_input.trim();
+            (!query.is_empty()).then_some(query.to_string())
+        } else {
+            None
+        };
+        let selected_hit = self.search_hits.get(self.search_cursor).copied();
+        let selection = self.selection_range.and_then(|(service, start, end)| {
+            (service == active).then_some((start.min(end), start.max(end)))
+        });
+        let flash = self.copied_flash_range.and_then(|(service, start, end)| {
+            (service == active).then_some((start.min(end), start.max(end)))
+        });
+        let pane = &mut self.panes[active];
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(pane.color))
+            .title(
+                Line::from(Span::styled(
+                    format!(" Logs — {} ", pane.name),
+                    Style::default().fg(pane.color).add_modifier(Modifier::BOLD),
+                ))
+                .left_aligned(),
+            );
+        let inner = block.inner(logs);
+        pane.last_view_height = (inner.height as usize).max(1);
+        pane.last_view_width = (inner.width as usize).max(1);
+        if self.wrap {
+            let visual_scroll = pane.resolved_scroll_top(true);
+            if pane.scroll_top != usize::MAX {
+                pane.scroll_top = visual_scroll;
             }
-            _ => DashboardAction::None,
+            let (start, first_line_offset) = pane
+                .line_position_at_visual_offset(visual_scroll)
+                .unwrap_or((0, 0));
+            let mut remaining_rows = pane.last_view_height;
+            let mut rendered_rows = Vec::new();
+            for (offset, line) in pane.lines.iter().skip(start).enumerate() {
+                if remaining_rows == 0 {
+                    break;
+                }
+                let index = start + offset;
+                let mut rendered = highlight_line(
+                    &line.text,
+                    line.style,
+                    search_query.as_deref(),
+                    selected_hit == Some(index),
+                );
+                let selected = selection
+                    .map(|(from, to)| (from..=to).contains(&index))
+                    .unwrap_or(false);
+                let flashed = flash
+                    .map(|(from, to)| (from..=to).contains(&index))
+                    .unwrap_or(false);
+                for span in &mut rendered.spans {
+                    if flashed {
+                        span.style = span.style.patch(
+                            Style::default()
+                                .bg(Color::LightGreen)
+                                .fg(Color::Black)
+                                .add_modifier(Modifier::BOLD),
+                        );
+                    } else if selected && span.style.bg.is_none() {
+                        span.style = span.style.patch(Style::default().bg(Color::DarkGray));
+                    }
+                }
+                let rows = wrapped_line_rows(
+                    &rendered,
+                    pane.last_view_width,
+                    if offset == 0 { first_line_offset } else { 0 },
+                    remaining_rows,
+                );
+                remaining_rows = remaining_rows.saturating_sub(rows.len());
+                rendered_rows.extend(rows);
+            }
+            frame.render_widget(block, logs);
+            render_prewrapped_rows(frame, inner, &rendered_rows);
+        } else {
+            let start = pane.resolved_scroll_top(false);
+            if pane.scroll_top != usize::MAX {
+                pane.scroll_top = start;
+            }
+            let lines = pane
+                .lines
+                .iter()
+                .skip(start)
+                .take(pane.last_view_height)
+                .enumerate()
+                .map(|(offset, line)| {
+                    let index = start + offset;
+                    let mut rendered = highlight_line(
+                        &line.text,
+                        line.style,
+                        search_query.as_deref(),
+                        selected_hit == Some(index),
+                    );
+                    let selected = selection
+                        .map(|(from, to)| (from..=to).contains(&index))
+                        .unwrap_or(false);
+                    let flashed = flash
+                        .map(|(from, to)| (from..=to).contains(&index))
+                        .unwrap_or(false);
+                    for span in &mut rendered.spans {
+                        if flashed {
+                            span.style = span.style.patch(
+                                Style::default()
+                                    .bg(Color::LightGreen)
+                                    .fg(Color::Black)
+                                    .add_modifier(Modifier::BOLD),
+                            );
+                        } else if selected && span.style.bg.is_none() {
+                            span.style = span.style.patch(Style::default().bg(Color::DarkGray));
+                        }
+                    }
+                    rendered
+                })
+                .collect::<Vec<_>>();
+            frame.render_widget(Paragraph::new(lines).block(block), logs);
+        }
+
+        frame.render_widget(
+            Paragraph::new(
+                "h/l service   j/k scroll   [/] resize split   f fullscreen   w wrap   Enter bottom   m mouse   click service/[open]   drag split/select logs   y copy   Ctrl+f/b page   Ctrl+d/u half   / search   r restart   ? help   q quit",
+            )
+            .style(Style::default().fg(Color::DarkGray)),
+            root[2],
+        );
+
+        if self.input_mode == InputMode::Search {
+            let position = if self.search_hits.is_empty() {
+                "0/0".to_string()
+            } else {
+                format!("{}/{}", self.search_cursor + 1, self.search_hits.len())
+            };
+            frame.render_widget(
+                Paragraph::new(format!(
+                    "/{}  [{}]  Enter done  Esc cancel  Ctrl+n next  Ctrl+p/Ctrl+Shift+n prev",
+                    self.search_input, position
+                ))
+                .style(Style::default().fg(Color::White)),
+                root[3],
+            );
+        }
+        if let Some(path) = control_token_path {
+            frame.render_widget(
+                Paragraph::new(format!("control token: {path}"))
+                    .style(Style::default().fg(Color::DarkGray)),
+                root[4],
+            );
+        }
+        if self.show_help {
+            self.render_help_overlay(frame);
         }
     }
 
@@ -188,112 +810,798 @@ impl Dashboard {
         workspace: &str,
         control_token_path: Option<&str>,
     ) -> Result<()> {
-        let active = self.active_name().to_string();
-        let logs = self.logs.get(&active).cloned().unwrap_or_default();
-        let services = self.services.clone();
-        let states = self.states.clone();
-        let ports = self.ports.clone();
-        let active_index = self.active;
-        let wrap = self.wrap;
-        let fullscreen = self.fullscreen;
-        let scroll = self.scroll;
-        let footer_height = if control_token_path.is_some() { 3 } else { 1 };
-
-        terminal.draw(|frame| {
-            let outer = Layout::default()
-                .direction(Direction::Vertical)
-                .constraints([
-                    Constraint::Length(1),
-                    Constraint::Min(4),
-                    Constraint::Length(footer_height),
-                ])
-                .split(frame.area());
-            frame.render_widget(
-                Paragraph::new(workspace).style(Style::default().fg(Color::DarkGray)),
-                outer[0],
-            );
-            let body = if fullscreen {
-                vec![outer[1]]
-            } else {
-                Layout::default()
-                    .direction(Direction::Horizontal)
-                    .constraints([Constraint::Length(32), Constraint::Min(30)])
-                    .split(outer[1])
-                    .to_vec()
-            };
-
-            if !fullscreen {
-                let items = services.iter().enumerate().map(|(index, name)| {
-                    let state = states.get(name).copied().unwrap_or(ServiceState::Stopped);
-                    let port = ports
-                        .get(name)
-                        .copied()
-                        .flatten()
-                        .map(|port| format!(" :{port}"))
-                        .unwrap_or_default();
-                    let style = if index == active_index {
-                        Style::default()
-                            .fg(Color::Cyan)
-                            .add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default()
-                    };
-                    ListItem::new(Line::from(vec![
-                        Span::styled(format!("{name}{port}"), style),
-                        Span::styled(
-                            format!("  {}", state.label()),
-                            Style::default().fg(Color::DarkGray),
-                        ),
-                    ]))
-                });
-                frame.render_widget(
-                    List::new(items).block(Block::default().borders(Borders::ALL).title("services")),
-                    body[0],
-                );
-            }
-
-            let log_area = *body.last().expect("body always has a log area");
-            let height = log_area.height.saturating_sub(2) as usize;
-            let log_lines = logs.into_iter().collect::<Vec<_>>();
-            let rendered_height = if wrap {
-                Paragraph::new(log_lines.clone())
-                    .wrap(Wrap { trim: false })
-                    .line_count(log_area.width.saturating_sub(2))
-            } else {
-                log_lines.len()
-            };
-            let max_scroll =
-                u16::try_from(rendered_height.saturating_sub(height)).unwrap_or(u16::MAX);
-            self.max_scroll = max_scroll;
-            let scroll = if scroll == u16::MAX {
-                max_scroll
-            } else {
-                let clamped = scroll.min(max_scroll);
-                self.scroll = clamped;
-                clamped
-            };
-            let paragraph = Paragraph::new(log_lines)
-                .block(Block::default().borders(Borders::ALL).title(active))
-                .scroll((scroll, 0));
-            let paragraph = if wrap {
-                paragraph.wrap(Wrap { trim: false })
-            } else {
-                paragraph
-            };
-            frame.render_widget(paragraph, log_area);
-            let help =
-                "h/l service  j/k scroll  Enter bottom  r restart  o open  w wrap  f fullscreen  q quit";
-            let footer = control_token_path
-                .map(|path| format!("control token: {path}\n{help}"))
-                .unwrap_or_else(|| help.to_string());
-            frame.render_widget(
-                Paragraph::new(footer)
-                    .wrap(Wrap { trim: false })
-                    .style(Style::default().fg(Color::DarkGray)),
-                outer[2],
-            );
-        })?;
+        terminal.draw(|frame| self.render(frame, workspace, control_token_path))?;
         Ok(())
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DashboardAction {
+        if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            return DashboardAction::Quit;
+        }
+        if self.input_mode == InputMode::Search {
+            return self.handle_search_key(key);
+        }
+        if self.show_help {
+            return match key.code {
+                KeyCode::Char('?') | KeyCode::Esc => {
+                    self.show_help = false;
+                    self.status = "controls hidden".to_string();
+                    DashboardAction::Draw
+                }
+                KeyCode::Char('q') => DashboardAction::Quit,
+                _ => DashboardAction::None,
+            };
+        }
+
+        match key.code {
+            KeyCode::Char('q') => DashboardAction::Quit,
+            KeyCode::Char('r') => DashboardAction::Restart(self.active_name().to_string()),
+            KeyCode::Char('o') => DashboardAction::Open,
+            KeyCode::Char('m') => {
+                self.mouse_enabled = !self.mouse_enabled;
+                self.status = if self.mouse_enabled {
+                    "mouse mode on: dashboard click/scroll enabled".to_string()
+                } else {
+                    "mouse mode off: terminal text selection enabled".to_string()
+                };
+                DashboardAction::ToggleMouse(self.mouse_enabled)
+            }
+            KeyCode::Char('?') => {
+                self.show_help = true;
+                self.status = "controls shown (? / Esc to close)".to_string();
+                DashboardAction::Draw
+            }
+            KeyCode::Char('f') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.fullscreen = !self.fullscreen;
+                self.status = if self.fullscreen {
+                    format!("fullscreen: {}", self.active_name())
+                } else {
+                    "service list restored".to_string()
+                };
+                DashboardAction::Draw
+            }
+            KeyCode::Char('h') | KeyCode::Left => {
+                let next = if self.active == 0 {
+                    self.panes.len() - 1
+                } else {
+                    self.active - 1
+                };
+                self.set_active(next);
+                DashboardAction::Draw
+            }
+            KeyCode::Char('l') | KeyCode::Right | KeyCode::Tab => {
+                self.set_active((self.active + 1) % self.panes.len());
+                DashboardAction::Draw
+            }
+            KeyCode::Char('[') => {
+                self.resize_service_list(-DIVIDER_RESIZE_STEP);
+                DashboardAction::Draw
+            }
+            KeyCode::Char(']') => {
+                self.resize_service_list(DIVIDER_RESIZE_STEP);
+                DashboardAction::Draw
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                let wrap = self.wrap;
+                self.active_pane_mut().scroll_lines(1, wrap);
+                DashboardAction::Draw
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                let wrap = self.wrap;
+                self.active_pane_mut().scroll_lines(-1, wrap);
+                DashboardAction::Draw
+            }
+            KeyCode::PageDown | KeyCode::Char('f')
+                if key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                let wrap = self.wrap;
+                self.active_pane_mut().scroll_page(1, false, wrap);
+                DashboardAction::Draw
+            }
+            KeyCode::PageUp | KeyCode::Char('b')
+                if key.modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                let wrap = self.wrap;
+                self.active_pane_mut().scroll_page(-1, false, wrap);
+                DashboardAction::Draw
+            }
+            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let wrap = self.wrap;
+                self.active_pane_mut().scroll_page(1, true, wrap);
+                DashboardAction::Draw
+            }
+            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                let wrap = self.wrap;
+                self.active_pane_mut().scroll_page(-1, true, wrap);
+                DashboardAction::Draw
+            }
+            KeyCode::Enter => {
+                self.active_pane_mut().scroll_to_bottom();
+                self.status = "scrolled to bottom".to_string();
+                DashboardAction::Draw
+            }
+            KeyCode::Char('w') => {
+                let was_wrapped = self.wrap;
+                self.wrap = !self.wrap;
+                for pane in &mut self.panes {
+                    if pane.scroll_top == usize::MAX {
+                        continue;
+                    }
+                    pane.scroll_top = if self.wrap && !was_wrapped {
+                        pane.visual_offset_for_line(pane.scroll_top)
+                    } else if !self.wrap && was_wrapped {
+                        pane.line_position_at_visual_offset(pane.scroll_top)
+                            .map(|(line, _)| line)
+                            .unwrap_or(0)
+                    } else {
+                        pane.scroll_top
+                    };
+                    pane.scroll_top = pane.scroll_top.min(pane.max_scroll_top(self.wrap));
+                }
+                self.status = if self.wrap {
+                    "line wrapping enabled".to_string()
+                } else {
+                    "line wrapping disabled".to_string()
+                };
+                DashboardAction::Draw
+            }
+            KeyCode::Char('/') => {
+                self.input_mode = InputMode::Search;
+                self.search_input.clear();
+                self.refresh_search();
+                DashboardAction::Draw
+            }
+            KeyCode::Char('y') => {
+                if let Err(error) = self.copy_selection() {
+                    self.status = format!("copy failed: {error}");
+                }
+                DashboardAction::Draw
+            }
+            KeyCode::Esc => {
+                self.clear_selection();
+                self.status = "selection cleared".to_string();
+                DashboardAction::Draw
+            }
+            _ => DashboardAction::None,
+        }
+    }
+
+    fn handle_search_key(&mut self, key: KeyEvent) -> DashboardAction {
+        match key.code {
+            KeyCode::Esc => {
+                self.input_mode = InputMode::Normal;
+                self.search_input.clear();
+                self.search_hits.clear();
+                self.search_cursor = 0;
+                self.status = "search canceled".to_string();
+            }
+            KeyCode::Enter => {
+                let query = self.search_input.trim().to_string();
+                self.status = if query.is_empty() {
+                    "search cleared".to_string()
+                } else {
+                    format!("search done: {query} ({})", self.search_hits.len())
+                };
+                self.input_mode = InputMode::Normal;
+                self.search_input.clear();
+                self.search_hits.clear();
+                self.search_cursor = 0;
+            }
+            KeyCode::Backspace => {
+                self.search_input.pop();
+                self.refresh_search();
+            }
+            KeyCode::Up => self.search_next(false),
+            KeyCode::Down => self.search_next(true),
+            KeyCode::Char(character)
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && matches!(character, 'n' | 'N' | 'p') =>
+            {
+                self.search_next(!matches!(character, 'N' | 'p'));
+            }
+            KeyCode::Char(character) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.search_input.push(character);
+                self.refresh_search();
+            }
+            _ => {}
+        }
+        DashboardAction::Draw
+    }
+
+    fn refresh_search(&mut self) {
+        let query = self.search_input.trim().to_ascii_lowercase();
+        self.search_hits.clear();
+        self.search_cursor = 0;
+        if query.is_empty() {
+            return;
+        }
+        self.search_hits = self.panes[self.active]
+            .lines
+            .iter()
+            .enumerate()
+            .filter_map(|(index, line)| {
+                line.text
+                    .to_ascii_lowercase()
+                    .contains(&query)
+                    .then_some(index)
+            })
+            .collect();
+        self.jump_to_search_hit();
+    }
+
+    fn search_next(&mut self, forward: bool) {
+        if self.search_hits.is_empty() {
+            return;
+        }
+        self.search_cursor = if forward {
+            (self.search_cursor + 1) % self.search_hits.len()
+        } else if self.search_cursor == 0 {
+            self.search_hits.len() - 1
+        } else {
+            self.search_cursor - 1
+        };
+        self.jump_to_search_hit();
+    }
+
+    fn jump_to_search_hit(&mut self) {
+        if let Some(&line) = self.search_hits.get(self.search_cursor) {
+            let wrap = self.wrap;
+            let pane = &mut self.panes[self.active];
+            pane.scroll_top = if wrap {
+                pane.visual_offset_for_line(line).saturating_sub(2)
+            } else {
+                line.saturating_sub(2)
+            };
+            pane.scroll_top = pane.scroll_top.min(pane.max_scroll_top(wrap));
+        }
+    }
+
+    pub fn handle_mouse(
+        &mut self,
+        mouse: MouseEvent,
+        area: Rect,
+        control_token_path: Option<&str>,
+    ) -> DashboardAction {
+        if !self.mouse_enabled || self.show_help {
+            return DashboardAction::None;
+        }
+        let (service_list, divider, logs) = self.workspace_layout(area, control_token_path);
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                if divider.is_some_and(|rect| rect.contains((mouse.column, mouse.row).into())) {
+                    self.divider_dragging = true;
+                    self.clear_selection();
+                    self.status = "resizing service list".to_string();
+                    return DashboardAction::Draw;
+                }
+                if let Some(list) = service_list {
+                    if let Some(index) = self.service_index_at(list, mouse.column, mouse.row) {
+                        let open = self.open_link_contains(list, index, mouse.column, mouse.row);
+                        self.set_active(index);
+                        return if open {
+                            DashboardAction::Open
+                        } else {
+                            DashboardAction::Draw
+                        };
+                    }
+                }
+                if logs.contains((mouse.column, mouse.row).into()) {
+                    if let Some(line) = self.log_line_at(logs, mouse.row) {
+                        self.selection_anchor = Some((self.active, line));
+                        self.selection_range = Some((self.active, line, line));
+                        self.selection_dragging = false;
+                    }
+                    return DashboardAction::Draw;
+                }
+            }
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if self.divider_dragging {
+                    let workspace = self.root_layout(area, control_token_path)[1];
+                    self.set_service_list_width_from_column(mouse.column, workspace);
+                    return DashboardAction::Draw;
+                }
+                if let Some((service, anchor)) = self.selection_anchor {
+                    if service == self.active && logs.contains((mouse.column, mouse.row).into()) {
+                        if let Some(line) = self.log_line_at(logs, mouse.row) {
+                            self.selection_range = Some((service, anchor, line));
+                            self.selection_dragging = true;
+                        }
+                    }
+                    return DashboardAction::Draw;
+                }
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if self.divider_dragging {
+                    let workspace = self.root_layout(area, control_token_path)[1];
+                    self.set_service_list_width_from_column(mouse.column, workspace);
+                    self.divider_dragging = false;
+                    return DashboardAction::Draw;
+                }
+                if self.selection_dragging {
+                    if let Some((_, start, end)) = self.selection_range {
+                        self.status = format!(
+                            "selected {} line(s) in {} (press y to copy)",
+                            start.max(end).saturating_sub(start.min(end)) + 1,
+                            self.active_name()
+                        );
+                    }
+                }
+                self.selection_anchor = None;
+                self.selection_dragging = false;
+                return DashboardAction::Draw;
+            }
+            MouseEventKind::ScrollUp => {
+                if service_list.is_some_and(|rect| rect.contains((mouse.column, mouse.row).into()))
+                {
+                    self.scroll_service_list(-1);
+                } else if logs.contains((mouse.column, mouse.row).into()) {
+                    let wrap = self.wrap;
+                    self.active_pane_mut().scroll_lines(-3, wrap);
+                }
+                return DashboardAction::Draw;
+            }
+            MouseEventKind::ScrollDown => {
+                if service_list.is_some_and(|rect| rect.contains((mouse.column, mouse.row).into()))
+                {
+                    self.scroll_service_list(1);
+                } else if logs.contains((mouse.column, mouse.row).into()) {
+                    let wrap = self.wrap;
+                    self.active_pane_mut().scroll_lines(3, wrap);
+                }
+                return DashboardAction::Draw;
+            }
+            _ => {}
+        }
+        DashboardAction::None
+    }
+
+    fn service_index_at(&self, list: Rect, x: u16, y: u16) -> Option<usize> {
+        let inner = Self::service_list_body_rect(list);
+        if !inner.contains((x, y).into()) {
+            return None;
+        }
+        let index = self
+            .service_list_scroll
+            .saturating_add(((y - inner.y) / SERVICE_TAB_ROWS) as usize);
+        (index < self.panes.len()).then_some(index)
+    }
+
+    fn open_link_contains(&self, list: Rect, index: usize, x: u16, y: u16) -> bool {
+        let inner = Self::service_list_body_rect(list);
+        let slot = index.saturating_sub(self.service_list_scroll) as u16;
+        let row = inner
+            .y
+            .saturating_add(slot.saturating_mul(SERVICE_TAB_ROWS));
+        self.panes[index].url.is_some()
+            && y == row
+            && x >= inner
+                .x
+                .saturating_add(inner.width)
+                .saturating_sub(OPEN_LINK_LABEL.len() as u16)
+    }
+
+    fn log_line_at(&mut self, logs: Rect, y: u16) -> Option<usize> {
+        let inner = Rect::new(
+            logs.x.saturating_add(1),
+            logs.y.saturating_add(1),
+            logs.width.saturating_sub(2),
+            logs.height.saturating_sub(2),
+        );
+        if y < inner.y || y >= inner.y.saturating_add(inner.height) {
+            return None;
+        }
+        let wrap = self.wrap;
+        let pane = &mut self.panes[self.active];
+        let offset = pane
+            .resolved_scroll_top(wrap)
+            .saturating_add((y - inner.y) as usize);
+        let index = if wrap {
+            pane.line_position_at_visual_offset(offset)
+                .map(|(line, _)| line)?
+        } else {
+            offset
+        };
+        (index < pane.lines.len()).then_some(index)
+    }
+
+    fn clear_selection(&mut self) {
+        self.selection_anchor = None;
+        self.selection_range = None;
+        self.selection_dragging = false;
+    }
+
+    fn copy_selection(&mut self) -> Result<()> {
+        let Some((service, start, end)) = self.selection_range else {
+            return Err(anyhow!("no selection"));
+        };
+        let from = start.min(end);
+        let to = start.max(end);
+        let text = self.panes[service]
+            .lines
+            .iter()
+            .skip(from)
+            .take(to.saturating_sub(from) + 1)
+            .map(|line| line.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        if text.is_empty() {
+            return Err(anyhow!("selection is empty"));
+        }
+        copy_to_clipboard(&text)?;
+        let pane_name = self.panes[service].name.clone();
+        self.copied_flash_range = Some((service, from, to));
+        self.copied_flash_until = Some(Instant::now() + COPY_FLASH_DURATION);
+        self.clear_selection();
+        self.status = format!(
+            "copied {} line(s) from {pane_name}",
+            to.saturating_sub(from) + 1
+        );
+        Ok(())
+    }
+
+    fn clear_copy_flash_if_expired(&mut self) {
+        if self
+            .copied_flash_until
+            .is_some_and(|until| Instant::now() >= until)
+        {
+            self.copied_flash_until = None;
+            self.copied_flash_range = None;
+        }
+    }
+
+    fn render_help_overlay(&self, frame: &mut ratatui::Frame<'_>) {
+        let area = centered_rect(80, 80, frame.area());
+        let lines = vec![
+            Line::from(Span::styled(
+                "Controls",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            )),
+            Line::from(""),
+            Line::from("Service focus: h/l or Left/Right"),
+            Line::from("Resize service/log split: drag divider or [ / ]"),
+            Line::from("Fullscreen: f toggles active logs fullscreen"),
+            Line::from("Mouse mode toggle: m"),
+            Line::from("Mouse mode on: click [open], wheel lists/logs, drag selections"),
+            Line::from("Mouse mode off: native terminal text selection works"),
+            Line::from("Log copy: drag lines, y to copy, Esc to clear"),
+            Line::from("Scroll: j/k or Up/Down; Enter jumps to bottom"),
+            Line::from("Page: Ctrl+f / Ctrl+b or PageDown/PageUp"),
+            Line::from("Half-page: Ctrl+d / Ctrl+u"),
+            Line::from("Search: /; Ctrl+n next; Ctrl+p/Ctrl+Shift+n previous"),
+            Line::from("Toggle line wrapping: w"),
+            Line::from("Manual restart selected service: r"),
+            Line::from("Toggle controls: ?"),
+            Line::from("Quit: q"),
+            Line::from(""),
+            Line::from("Press ? or Esc to close this panel"),
+        ];
+        frame.render_widget(Clear, area);
+        frame.render_widget(
+            Paragraph::new(lines)
+                .block(
+                    Block::default()
+                        .title("Controls")
+                        .borders(Borders::ALL)
+                        .border_style(Style::default().fg(Color::Yellow)),
+                )
+                .wrap(Wrap { trim: false })
+                .style(Style::default().bg(Color::Black).fg(Color::White)),
+            area,
+        );
+    }
+}
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
+}
+
+#[derive(Clone)]
+struct StyledSymbol {
+    symbol: String,
+    style: Style,
+    width: usize,
+}
+
+fn is_wrappable_whitespace(symbol: &str) -> bool {
+    symbol == "\u{200b}" || symbol.chars().all(char::is_whitespace) && symbol != "\u{00a0}"
+}
+
+fn line_to_symbols(line: &Line<'static>) -> Vec<StyledSymbol> {
+    line.spans
+        .iter()
+        .flat_map(|span| {
+            span.content
+                .graphemes(true)
+                .filter(|symbol| *symbol != "\n")
+                .map(|symbol| StyledSymbol {
+                    symbol: symbol.to_string(),
+                    style: line.style.patch(span.style),
+                    width: symbol.width(),
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn symbols_to_line(symbols: &[StyledSymbol]) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    for symbol in symbols {
+        if let Some(last) = spans.last_mut() {
+            if last.style == symbol.style {
+                last.content.to_mut().push_str(&symbol.symbol);
+                continue;
+            }
+        }
+        spans.push(Span::styled(symbol.symbol.clone(), symbol.style));
+    }
+    Line::from(spans)
+}
+
+fn push_wrapped_row(
+    row: Vec<StyledSymbol>,
+    row_index: &mut usize,
+    skip: usize,
+    take: usize,
+    output: &mut Vec<Line<'static>>,
+) -> bool {
+    if *row_index >= skip && output.len() < take {
+        output.push(symbols_to_line(&row));
+    }
+    *row_index += 1;
+    output.len() >= take
+}
+
+fn wrapped_line_rows(
+    line: &Line<'static>,
+    width: usize,
+    skip: usize,
+    take: usize,
+) -> Vec<Line<'static>> {
+    if width == 0 || take == 0 {
+        return Vec::new();
+    }
+    let mut output = Vec::new();
+    let mut row_index = 0;
+    let mut pending_line = Vec::new();
+    let mut line_width = 0;
+    let mut pending_word = Vec::new();
+    let mut word_width = 0;
+    let mut pending_whitespace = VecDeque::new();
+    let mut whitespace_width = 0;
+    let mut previous_was_non_whitespace = false;
+
+    for symbol in line_to_symbols(line) {
+        let whitespace = is_wrappable_whitespace(&symbol.symbol);
+        let symbol_width = symbol.width;
+        if symbol_width > width {
+            continue;
+        }
+        let word_complete = previous_was_non_whitespace && whitespace;
+        let initial_overflow =
+            pending_line.is_empty() && word_width + whitespace_width + symbol_width > width;
+        if word_complete || initial_overflow {
+            pending_line.extend(pending_whitespace.drain(..));
+            line_width += whitespace_width;
+            whitespace_width = 0;
+            pending_line.append(&mut pending_word);
+            line_width += word_width;
+            word_width = 0;
+        }
+        let overflow = symbol_width > 0 && line_width + whitespace_width + word_width >= width;
+        if line_width >= width || overflow {
+            let mut remaining = width.saturating_sub(line_width);
+            if push_wrapped_row(
+                std::mem::take(&mut pending_line),
+                &mut row_index,
+                skip,
+                take,
+                &mut output,
+            ) {
+                return output;
+            }
+            line_width = 0;
+            while let Some(next_width) = pending_whitespace.front().map(|next| next.width) {
+                if next_width > remaining {
+                    break;
+                }
+                whitespace_width = whitespace_width.saturating_sub(next_width);
+                remaining = remaining.saturating_sub(next_width);
+                pending_whitespace.pop_front();
+            }
+            if whitespace && pending_whitespace.is_empty() {
+                previous_was_non_whitespace = false;
+                continue;
+            }
+        }
+        if whitespace {
+            whitespace_width += symbol_width;
+            pending_whitespace.push_back(symbol);
+        } else {
+            word_width += symbol_width;
+            pending_word.push(symbol);
+        }
+        previous_was_non_whitespace = !whitespace;
+    }
+
+    if pending_line.is_empty()
+        && pending_word.is_empty()
+        && !pending_whitespace.is_empty()
+        && push_wrapped_row(Vec::new(), &mut row_index, skip, take, &mut output)
+    {
+        return output;
+    }
+    pending_line.extend(pending_whitespace.drain(..));
+    pending_line.append(&mut pending_word);
+    if !pending_line.is_empty()
+        && push_wrapped_row(pending_line, &mut row_index, skip, take, &mut output)
+    {
+        return output;
+    }
+    if row_index == 0 {
+        let _ = push_wrapped_row(Vec::new(), &mut row_index, skip, take, &mut output);
+    }
+    output
+}
+
+fn render_prewrapped_rows(frame: &mut ratatui::Frame<'_>, area: Rect, rows: &[Line<'static>]) {
+    if area.is_empty() {
+        return;
+    }
+    let buffer = frame.buffer_mut();
+    for y in area.y..area.y.saturating_add(area.height) {
+        for x in area.x..area.x.saturating_add(area.width) {
+            buffer[(x, y)].set_symbol(" ").set_style(Style::default());
+        }
+    }
+    for (row_index, row) in rows.iter().take(area.height as usize).enumerate() {
+        let y = area.y + row_index as u16;
+        let mut x = 0;
+        'spans: for span in &row.spans {
+            let style = row.style.patch(span.style);
+            for symbol in span
+                .content
+                .graphemes(true)
+                .filter(|symbol| *symbol != "\n")
+            {
+                let width = symbol.width();
+                if width == 0 {
+                    continue;
+                }
+                if x >= area.width {
+                    break 'spans;
+                }
+                buffer[(area.x + x, y)]
+                    .set_symbol(if symbol.is_empty() { " " } else { symbol })
+                    .set_style(style);
+                x = x.saturating_add(width as u16);
+            }
+        }
+    }
+}
+
+fn highlight_line(
+    text: &str,
+    base_style: Style,
+    query: Option<&str>,
+    current_match: bool,
+) -> Line<'static> {
+    let Some(query) = query.map(str::trim).filter(|query| !query.is_empty()) else {
+        return Line::from(Span::styled(text.to_string(), base_style));
+    };
+    let needle = query.to_ascii_lowercase();
+    let haystack = text.to_ascii_lowercase();
+    let mut spans = Vec::new();
+    let mut cursor = 0;
+    let mut highlighted_current = false;
+    while let Some(found) = haystack[cursor..].find(&needle) {
+        let start = cursor + found;
+        let end = start + needle.len();
+        if start > cursor {
+            spans.push(Span::styled(text[cursor..start].to_string(), base_style));
+        }
+        let style = if current_match && !highlighted_current {
+            highlighted_current = true;
+            base_style
+                .bg(Color::Blue)
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            base_style
+                .bg(Color::Yellow)
+                .fg(Color::Black)
+                .add_modifier(Modifier::BOLD)
+        };
+        spans.push(Span::styled(text[start..end].to_string(), style));
+        cursor = end;
+    }
+    if cursor < text.len() {
+        spans.push(Span::styled(text[cursor..].to_string(), base_style));
+    }
+    if spans.is_empty() {
+        Line::from(Span::styled(text.to_string(), base_style))
+    } else {
+        Line::from(spans)
+    }
+}
+
+fn copy_to_clipboard(text: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    let (program, args): (&str, &[&str]) = ("pbcopy", &[]);
+    #[cfg(target_os = "windows")]
+    let (program, args): (&str, &[&str]) = ("clip", &[]);
+    #[cfg(target_os = "linux")]
+    {
+        for (program, args) in [
+            ("wl-copy", &[][..]),
+            ("xclip", &["-selection", "clipboard"][..]),
+        ] {
+            if copy_with(program, args, text).is_ok() {
+                return Ok(());
+            }
+        }
+        return Err(anyhow!("clipboard helper not found (tried wl-copy, xclip)"));
+    }
+    #[cfg(not(target_os = "linux"))]
+    copy_with(program, args, text)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn copy_with(program: &str, args: &[&str], text: &str) -> Result<()> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to start {program}"))?;
+    child
+        .stdin
+        .as_mut()
+        .context("clipboard stdin unavailable")?
+        .write_all(text.as_bytes())
+        .with_context(|| format!("failed writing to {program}"))?;
+    let status = child
+        .wait()
+        .with_context(|| format!("failed waiting for {program}"))?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("{program} failed with status {status}"))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn copy_with(program: &str, args: &[&str], text: &str) -> Result<()> {
+    let mut child = Command::new(program)
+        .args(args)
+        .stdin(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed to start {program}"))?;
+    child
+        .stdin
+        .as_mut()
+        .context("clipboard stdin unavailable")?
+        .write_all(text.as_bytes())?;
+    let status = child.wait()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(anyhow!("{program} failed with status {status}"))
     }
 }
 
@@ -307,19 +1615,15 @@ fn strip_ansi_sequences(input: &str) -> String {
             index += 1;
             continue;
         }
-
         index += 1;
         let Some(&kind) = bytes.get(index) else {
             break;
         };
-        // ESC can be followed by ordinary UTF-8 in malformed service output.
-        // Leave the complete non-ASCII code point for the normal copy path.
         if !kind.is_ascii() {
             continue;
         }
         index += 1;
         match kind {
-            // Control Sequence Introducer: consume through its final byte.
             b'[' => {
                 while let Some(&byte) = bytes.get(index) {
                     index += 1;
@@ -328,7 +1632,6 @@ fn strip_ansi_sequences(input: &str) -> String {
                     }
                 }
             }
-            // Operating System Command: terminated by BEL or String Terminator.
             b']' => {
                 while let Some(&byte) = bytes.get(index) {
                     index += 1;
@@ -341,7 +1644,6 @@ fn strip_ansi_sequences(input: &str) -> String {
                     }
                 }
             }
-            // DCS, SOS, PM, and APC strings are terminated by ESC backslash.
             b'P' | b'X' | b'^' | b'_' => {
                 while let Some(&byte) = bytes.get(index) {
                     index += 1;
@@ -351,7 +1653,6 @@ fn strip_ansi_sequences(input: &str) -> String {
                     }
                 }
             }
-            // Other escape sequences are two bytes long.
             _ => {}
         }
     }
@@ -363,36 +1664,58 @@ pub enum DashboardAction {
     Draw,
     Restart(String),
     Open,
+    ToggleMouse(bool),
     Quit,
 }
 
 pub struct TerminalGuard {
     pub terminal: Terminal<CrosstermBackend<io::Stdout>>,
+    mouse_capture: bool,
 }
 
 impl TerminalGuard {
     pub fn enter() -> Result<Self> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        if let Err(error) = stdout.execute(EnterAlternateScreen) {
+        if let Err(error) = execute!(stdout, EnterAlternateScreen, EnableMouseCapture) {
+            let _ = execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen);
             let _ = disable_raw_mode();
             return Err(error.into());
         }
         let terminal = match Terminal::new(CrosstermBackend::new(stdout)) {
             Ok(terminal) => terminal,
             Err(error) => {
-                let _ = execute!(io::stdout(), LeaveAlternateScreen);
+                let _ = execute!(io::stdout(), DisableMouseCapture, LeaveAlternateScreen);
                 let _ = disable_raw_mode();
                 return Err(error.into());
             }
         };
-        Ok(Self { terminal })
+        Ok(Self {
+            terminal,
+            mouse_capture: true,
+        })
+    }
+
+    pub fn set_mouse_capture(&mut self, enabled: bool) -> Result<()> {
+        if self.mouse_capture == enabled {
+            return Ok(());
+        }
+        if enabled {
+            execute!(io::stdout(), EnableMouseCapture)?;
+        } else {
+            execute!(io::stdout(), DisableMouseCapture)?;
+        }
+        self.mouse_capture = enabled;
+        Ok(())
     }
 }
 
 impl Drop for TerminalGuard {
     fn drop(&mut self) {
         let _ = self.terminal.show_cursor();
+        if self.mouse_capture {
+            let _ = execute!(io::stdout(), DisableMouseCapture);
+        }
         let _ = disable_raw_mode();
         let _ = execute!(io::stdout(), LeaveAlternateScreen);
     }
@@ -400,7 +1723,189 @@ impl Drop for TerminalGuard {
 
 #[cfg(test)]
 mod tests {
-    use super::strip_ansi_sequences;
+    use super::*;
+
+    fn services(entries: &[(&str, u16)]) -> Dashboard {
+        Dashboard::from_specs(
+            entries
+                .iter()
+                .map(|(name, port)| {
+                    (
+                        (*name).to_string(),
+                        Some(*port),
+                        Some(format!("http://localhost:{port}")),
+                    )
+                })
+                .collect(),
+        )
+    }
+
+    fn terminal_text(
+        terminal: &Terminal<ratatui::backend::TestBackend>,
+        width: u16,
+        height: u16,
+    ) -> String {
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| terminal.backend().buffer()[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn renders_scalable_colored_service_tabs_and_focused_logs() {
+        let mut dashboard = services(&[
+            ("platform", 4000),
+            ("developer-portal", 3300),
+            ("user-portal", 3400),
+        ]);
+        for (name, line) in [
+            ("platform", "PLATFORM_READY"),
+            ("developer-portal", "DEVELOPER_READY"),
+            ("user-portal", "USER_READY"),
+        ] {
+            dashboard.set_state(name, ServiceState::Running);
+            dashboard.push_system(name, line);
+        }
+        let width = 100;
+        let height = 18;
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| dashboard.render(frame, "/repo · branch", None))
+            .unwrap();
+        let first = terminal_text(&terminal, width, height);
+        assert!(first.contains("platform"));
+        assert!(first.contains("developer-portal"));
+        assert!(first.contains("user-portal"));
+        assert!(first.contains("localhost:4000"));
+        assert!(first.contains("PLATFORM_READY"));
+        assert!(!first.contains("DEVELOPER_READY"));
+        assert_eq!(terminal.backend().buffer()[(1, 3)].fg, Color::Cyan);
+
+        let area = Rect::new(0, 0, width, height);
+        assert!(matches!(
+            dashboard.handle_mouse(
+                MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: 2,
+                    row: 7,
+                    modifiers: KeyModifiers::NONE,
+                },
+                area,
+                None,
+            ),
+            DashboardAction::Draw
+        ));
+        assert!(matches!(
+            dashboard.handle_mouse(
+                MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: 38,
+                    row: 6,
+                    modifiers: KeyModifiers::NONE,
+                },
+                area,
+                None,
+            ),
+            DashboardAction::Draw
+        ));
+        dashboard.handle_mouse(
+            MouseEvent {
+                kind: MouseEventKind::Drag(MouseButton::Left),
+                column: 46,
+                row: 6,
+                modifiers: KeyModifiers::NONE,
+            },
+            area,
+            None,
+        );
+        dashboard.handle_mouse(
+            MouseEvent {
+                kind: MouseEventKind::Up(MouseButton::Left),
+                column: 46,
+                row: 6,
+                modifiers: KeyModifiers::NONE,
+            },
+            area,
+            None,
+        );
+        terminal
+            .draw(|frame| dashboard.render(frame, "/repo · branch", None))
+            .unwrap();
+        let second = terminal_text(&terminal, width, height);
+        assert_eq!(dashboard.active, 1);
+        assert_eq!(dashboard.service_list_width, 46);
+        assert!(second.contains("DEVELOPER_READY"));
+        assert!(!second.contains("PLATFORM_READY"));
+    }
+
+    #[test]
+    fn service_list_scroll_and_divider_resize_keep_large_stacks_navigable() {
+        let specs = (0..8)
+            .map(|index| {
+                (
+                    format!("service-{index}"),
+                    Some(4100 + index),
+                    Some(format!("http://localhost:{}", 4100 + index)),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut dashboard = Dashboard::from_specs(specs);
+        dashboard.set_active(7);
+        let width = 80;
+        let height = 12;
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| dashboard.render(frame, "/repo", None))
+            .unwrap();
+        assert!(dashboard.service_list_scroll > 0);
+        let original = dashboard.service_list_width;
+        assert!(matches!(
+            dashboard.handle_key(KeyEvent::new(KeyCode::Char(']'), KeyModifiers::NONE)),
+            DashboardAction::Draw
+        ));
+        assert!(dashboard.service_list_width > original);
+    }
+
+    #[test]
+    fn search_navigation_selects_matching_log_lines() {
+        let mut dashboard = services(&[("platform", 4000)]);
+        dashboard.push_system("platform", "first needle");
+        dashboard.push_system("platform", "other");
+        dashboard.push_system("platform", "second needle");
+        dashboard.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
+        for character in "needle".chars() {
+            dashboard.handle_key(KeyEvent::new(KeyCode::Char(character), KeyModifiers::NONE));
+        }
+        assert_eq!(dashboard.search_hits, vec![0, 2]);
+        dashboard.handle_key(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL));
+        assert_eq!(dashboard.search_cursor, 1);
+    }
+
+    #[test]
+    fn wrapping_uses_visual_rows_and_preserves_unicode_graphemes() {
+        let line = Line::from(vec![
+            Span::styled("aaaaa ", Style::default().fg(Color::Cyan)),
+            Span::styled("bbbbb 🦀 ccccc", Style::default().fg(Color::Yellow)),
+        ]);
+        let rows = wrapped_line_rows(&line, 10, 0, usize::MAX);
+        assert_eq!(rows.len(), 3);
+        let text = rows
+            .iter()
+            .flat_map(|row| row.spans.iter())
+            .map(|span| span.content.as_ref())
+            .collect::<String>();
+        assert!(text.contains('🦀'));
+        assert!(rows
+            .iter()
+            .flat_map(|row| &row.spans)
+            .any(|span| span.style.fg == Some(Color::Yellow)));
+    }
 
     #[test]
     fn strips_terminal_control_sequences_from_service_logs() {

--- a/src/dev/dashboard.rs
+++ b/src/dev/dashboard.rs
@@ -1556,7 +1556,7 @@ fn copy_to_clipboard(text: &str) -> Result<()> {
                 return Ok(());
             }
         }
-        return Err(anyhow!("clipboard helper not found (tried wl-copy, xclip)"));
+        Err(anyhow!("clipboard helper not found (tried wl-copy, xclip)"))
     }
     #[cfg(not(target_os = "linux"))]
     copy_with(program, args, text)

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -1,0 +1,9 @@
+//! Config-driven local service supervision for `aster dev`.
+
+mod dashboard;
+mod plan;
+mod process;
+mod runner;
+
+pub use plan::{resolve_dev_plan, DevPlan, ServicePlan};
+pub use runner::{run_dev, DevOptions};

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -1,4 +1,4 @@
-//! Config-driven local service supervision for `aster dev`.
+//! Config-driven local service supervision for `aster services up`.
 
 mod dashboard;
 mod plan;

--- a/src/dev/plan.rs
+++ b/src/dev/plan.rs
@@ -1,0 +1,510 @@
+use std::collections::{HashMap, HashSet};
+use std::env;
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+
+use crate::config::{DevPortConfig, DevWorkspaceConfig};
+use crate::discovery::DiscoveredProject;
+use crate::graph::TargetGraph;
+use crate::plugins::{PluginRegistry, Target};
+use crate::watch::WatchPlan;
+
+/// Fully resolved plan for one invocation of `aster dev`.
+pub struct DevPlan {
+    pub services: Vec<ServicePlan>,
+    pub ports: HashMap<String, u16>,
+    pub control_port: Option<u16>,
+}
+
+/// One configured long-running service.
+pub struct ServicePlan {
+    pub name: String,
+    pub target_address: String,
+    pub target: Target,
+    pub project_root: PathBuf,
+    pub port: Option<u16>,
+    pub open_url: Option<String>,
+    pub env: HashMap<String, String>,
+    pub watch: WatchPlan,
+}
+
+pub fn resolve_dev_plan(
+    workspace_root: &Path,
+    config: &DevWorkspaceConfig,
+    selected: &[String],
+    projects: &[DiscoveredProject],
+    graph: &TargetGraph,
+    plugins: &PluginRegistry,
+) -> Result<DevPlan> {
+    if config.services.is_empty() {
+        bail!("no services configured; add [dev.services.<name>] to aster.toml");
+    }
+
+    let port_file_env = load_env_files(workspace_root, &config.port_env_files)?;
+    let ports = resolve_ports(&config.ports, &port_file_env)?;
+    let control_port = config
+        .control_port
+        .as_deref()
+        .map(|name| {
+            ports
+                .get(name)
+                .copied()
+                .ok_or_else(|| anyhow!("dev control_port references unknown port '{name}'"))
+        })
+        .transpose()?;
+    let selected: HashSet<&str> = selected.iter().map(String::as_str).collect();
+
+    for name in &selected {
+        if !config.services.contains_key(*name) {
+            bail!("unknown dev service '{name}'");
+        }
+    }
+
+    let project_by_address: HashMap<String, &DiscoveredProject> = projects
+        .iter()
+        .map(|project| (format!("//{}", project.relative_path.display()), project))
+        .collect();
+    let mut configured = config.services.iter().collect::<Vec<_>>();
+    configured
+        .sort_by(|(name_a, a), (name_b, b)| a.order.cmp(&b.order).then_with(|| name_a.cmp(name_b)));
+
+    let mut services = Vec::new();
+    for (name, service) in configured {
+        if !selected.is_empty() && !selected.contains(name.as_str()) {
+            continue;
+        }
+
+        let (project_address, _) = service.target.split_once(':').ok_or_else(|| {
+            anyhow!(
+                "dev service '{name}' target must use //project:target syntax: {}",
+                service.target
+            )
+        })?;
+        let project = project_by_address.get(project_address).ok_or_else(|| {
+            anyhow!("dev service '{name}' references unknown project {project_address}")
+        })?;
+        let node = graph.get(&service.target).ok_or_else(|| {
+            anyhow!(
+                "dev service '{name}' references unknown target {}",
+                service.target
+            )
+        })?;
+        let target = project
+            .targets
+            .get(&node.target_name)
+            .ok_or_else(|| anyhow!("target definition missing for {}", service.target))?;
+        if !target.stream {
+            bail!(
+                "dev service '{name}' target {} must set stream = true",
+                service.target
+            );
+        }
+
+        let port = match service.port.as_deref() {
+            Some(port_name) => Some(*ports.get(port_name).ok_or_else(|| {
+                anyhow!("dev service '{name}' references unknown port '{port_name}'")
+            })?),
+            None => None,
+        };
+        let service_file_env = load_env_files(workspace_root, &service.env_files)?;
+        let mut service_env = service_file_env;
+        for key in &service.inherit_env {
+            validate_environment_key(name, key)?;
+            if let Ok(value) = env::var(key) {
+                service_env.insert(key.clone(), value);
+            }
+        }
+        for (key, value) in &service.env {
+            service_env.insert(
+                key.clone(),
+                expand_template(value, port, &ports).with_context(|| {
+                    format!("invalid env value for dev service '{name}' key '{key}'")
+                })?,
+            );
+        }
+        service_env.insert("ASTER_SERVICE_NAME".to_string(), name.clone());
+        if let Some(port) = port {
+            service_env.insert("ASTER_SERVICE_PORT".to_string(), port.to_string());
+        }
+        validate_environment(name, &service_env)?;
+
+        let mut target = target.clone();
+        target.command = expand_template(&target.command, port, &ports)
+            .with_context(|| format!("invalid command for dev service '{name}'"))?;
+        let open_url = port.map(|port| {
+            let path = service.open_path.as_deref().unwrap_or("");
+            let path = if path.is_empty() || path.starts_with('/') {
+                path.to_string()
+            } else {
+                format!("/{path}")
+            };
+            format!("http://localhost:{port}{path}")
+        });
+        let watch = WatchPlan::build(
+            std::slice::from_ref(&service.target),
+            projects,
+            graph,
+            plugins,
+        )
+        .with_context(|| format!("failed to build watch plan for dev service '{name}'"))?;
+
+        services.push(ServicePlan {
+            name: name.clone(),
+            target_address: service.target.clone(),
+            target,
+            project_root: project.root.clone(),
+            port,
+            open_url,
+            env: service_env,
+            watch,
+        });
+    }
+
+    if services.is_empty() {
+        bail!("no dev services selected");
+    }
+
+    Ok(DevPlan {
+        services,
+        ports,
+        control_port,
+    })
+}
+
+fn validate_environment(service: &str, environment: &HashMap<String, String>) -> Result<()> {
+    for (key, value) in environment {
+        validate_environment_key(service, key)?;
+        if value.contains('\0') {
+            bail!("dev service '{service}' environment value for '{key}' contains NUL");
+        }
+    }
+    Ok(())
+}
+
+fn validate_environment_key(service: &str, key: &str) -> Result<()> {
+    if key.is_empty() || key.contains('=') || key.contains('\0') {
+        bail!("dev service '{service}' has invalid environment key {key:?}");
+    }
+    Ok(())
+}
+
+fn load_env_files(workspace_root: &Path, files: &[String]) -> Result<HashMap<String, String>> {
+    let mut values = HashMap::new();
+    for configured_path in files {
+        let path = workspace_root.join(configured_path);
+        if !path.exists() {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read env file {}", path.display()))?;
+        for raw_line in content.lines() {
+            let line = raw_line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let line = line.strip_prefix("export ").unwrap_or(line);
+            let Some((key, value)) = line.split_once('=') else {
+                continue;
+            };
+            let key = key.trim();
+            if key.is_empty() {
+                continue;
+            }
+            let value = value.trim();
+            let value = if value.len() >= 2
+                && ((value.starts_with('"') && value.ends_with('"'))
+                    || (value.starts_with('\'') && value.ends_with('\'')))
+            {
+                &value[1..value.len() - 1]
+            } else {
+                value
+            };
+            values.insert(key.to_string(), value.to_string());
+        }
+    }
+    Ok(values)
+}
+
+fn resolve_ports(
+    configs: &HashMap<String, DevPortConfig>,
+    file_env: &HashMap<String, String>,
+) -> Result<HashMap<String, u16>> {
+    validate_port_offsets(configs)?;
+    let mut resolved: HashMap<String, u16> = HashMap::new();
+    let mut pending: HashSet<&str> = configs.keys().map(String::as_str).collect();
+
+    while !pending.is_empty() {
+        let before = pending.len();
+        for name in pending.clone() {
+            let config = &configs[name];
+            let value = match config {
+                DevPortConfig::Fixed(value) => Some(*value),
+                DevPortConfig::Resolved(config) => {
+                    let process_value = config
+                        .env
+                        .iter()
+                        .find_map(|key| env::var(key).ok().map(|raw| (key, raw)));
+                    let file_names = config.file_env.as_deref().unwrap_or(&config.env);
+                    let explicit = process_value.or_else(|| {
+                        file_names
+                            .iter()
+                            .find_map(|key| file_env.get(key).cloned().map(|raw| (key, raw)))
+                    });
+                    if let Some((key, raw)) = explicit {
+                        Some(raw.parse::<u16>().with_context(|| {
+                            format!("port '{name}' environment variable {key} is not a valid port")
+                        })?)
+                    } else if let Some(base_name) = config.offset_from.as_deref() {
+                        let Some(base_value) = resolved.get(base_name).copied() else {
+                            continue;
+                        };
+                        let offset_base = config.offset_base.ok_or_else(|| {
+                            anyhow!("port '{name}' sets offset_from but is missing offset_base")
+                        })?;
+                        let delta = if config.saturating_offset {
+                            base_value.saturating_sub(offset_base)
+                        } else {
+                            base_value.checked_sub(offset_base).ok_or_else(|| {
+                                anyhow!(
+                                    "port '{name}' offset source '{base_name}' ({base_value}) is below offset_base ({offset_base})"
+                                )
+                            })?
+                        };
+                        Some(config.default.checked_add(delta).ok_or_else(|| {
+                            anyhow!(
+                                "port '{name}' overflows: default {} + offset {delta} exceeds 65535",
+                                config.default
+                            )
+                        })?)
+                    } else {
+                        Some(config.default)
+                    }
+                }
+            };
+            if let Some(value) = value {
+                if value == 0 {
+                    bail!("port '{name}' must be between 1 and 65535");
+                }
+                resolved.insert(name.to_string(), value);
+                pending.remove(name);
+            }
+        }
+        if pending.len() == before {
+            let mut names = pending.into_iter().collect::<Vec<_>>();
+            names.sort_unstable();
+            bail!(
+                "unable to resolve dev ports (unknown or cyclic offset_from): {}",
+                names.join(", ")
+            );
+        }
+    }
+
+    Ok(resolved)
+}
+
+fn validate_port_offsets(configs: &HashMap<String, DevPortConfig>) -> Result<()> {
+    for (name, config) in configs {
+        let DevPortConfig::Resolved(config) = config else {
+            continue;
+        };
+        if config.offset_from.is_some() && config.offset_base.is_none() {
+            bail!("port '{name}' sets offset_from but is missing offset_base");
+        }
+        if config.offset_from.is_none() && config.offset_base.is_some() {
+            bail!("port '{name}' sets offset_base but is missing offset_from");
+        }
+        let mut current = name.as_str();
+        let mut seen = HashSet::new();
+        while let DevPortConfig::Resolved(current_config) = &configs[current] {
+            let Some(next) = current_config.offset_from.as_deref() else {
+                break;
+            };
+            if !seen.insert(current) {
+                bail!("dev port offset_from cycle includes '{current}'");
+            }
+            if !configs.contains_key(next) {
+                bail!("port '{current}' offset_from references unknown port '{next}'");
+            }
+            current = next;
+        }
+    }
+    Ok(())
+}
+
+fn expand_template(
+    value: &str,
+    service_port: Option<u16>,
+    ports: &HashMap<String, u16>,
+) -> Result<String> {
+    let mut expanded = value.to_string();
+    if expanded.contains("{port}") {
+        let port = service_port
+            .ok_or_else(|| anyhow!("uses {{port}} but the service has no configured port"))?;
+        expanded = expanded.replace("{port}", &port.to_string());
+    }
+    for (name, port) in ports {
+        expanded = expanded.replace(&format!("{{ports.{name}}}"), &port.to_string());
+    }
+    if let Some(start) = expanded.find("{ports.") {
+        let rest = &expanded[start..];
+        let end = rest.find('}').unwrap_or(rest.len().saturating_sub(1));
+        bail!("references unknown port template {}", &rest[..=end]);
+    }
+    Ok(expanded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ResolvedDevPortConfig;
+
+    #[test]
+    fn resolves_offset_ports_and_templates() {
+        let configs = HashMap::from([
+            ("api".to_string(), DevPortConfig::Fixed(4004)),
+            (
+                "web".to_string(),
+                DevPortConfig::Resolved(ResolvedDevPortConfig {
+                    env: vec![],
+                    file_env: None,
+                    default: 3300,
+                    offset_from: Some("api".to_string()),
+                    offset_base: Some(4000),
+                    saturating_offset: false,
+                }),
+            ),
+        ]);
+        let ports = resolve_ports(&configs, &HashMap::new()).unwrap();
+        assert_eq!(ports["web"], 3304);
+        assert_eq!(
+            expand_template("serve {port} --api {ports.api}", Some(3304), &ports).unwrap(),
+            "serve 3304 --api 4004"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_port_template() {
+        let error = expand_template("serve {ports.missing}", None, &HashMap::new()).unwrap_err();
+        assert!(error.to_string().contains("unknown port template"));
+    }
+
+    #[test]
+    fn rejects_invalid_derived_port_ranges() {
+        for (base, default, expected) in [
+            (3999, 3300, "below offset_base"),
+            (65000, 10000, "overflows"),
+        ] {
+            let configs = HashMap::from([
+                ("api".to_string(), DevPortConfig::Fixed(base)),
+                (
+                    "web".to_string(),
+                    DevPortConfig::Resolved(ResolvedDevPortConfig {
+                        env: vec![],
+                        file_env: None,
+                        default,
+                        offset_from: Some("api".to_string()),
+                        offset_base: Some(4000),
+                        saturating_offset: false,
+                    }),
+                ),
+            ]);
+            let error = resolve_ports(&configs, &HashMap::new()).unwrap_err();
+            assert!(error.to_string().contains(expected), "{error:#}");
+        }
+    }
+
+    #[test]
+    fn rejects_zero_named_port() {
+        let configs = HashMap::from([("control".to_string(), DevPortConfig::Fixed(0))]);
+        let error = resolve_ports(&configs, &HashMap::new()).unwrap_err();
+        assert!(error.to_string().contains("between 1 and 65535"));
+    }
+
+    #[test]
+    fn saturating_offset_accepts_source_below_baseline() {
+        let configs = HashMap::from([
+            ("api".to_string(), DevPortConfig::Fixed(3999)),
+            (
+                "web".to_string(),
+                DevPortConfig::Resolved(ResolvedDevPortConfig {
+                    env: vec![],
+                    file_env: None,
+                    default: 3300,
+                    offset_from: Some("api".to_string()),
+                    offset_base: Some(4000),
+                    saturating_offset: true,
+                }),
+            ),
+        ]);
+        let ports = resolve_ports(&configs, &HashMap::new()).unwrap();
+        assert_eq!(ports["web"], 3300);
+    }
+
+    #[test]
+    fn explicit_empty_file_env_disables_port_file_lookup() {
+        let key = "ASTER_TEST_PORT_EXPLICIT_EMPTY_FILE_ENV";
+        let configs = HashMap::from([(
+            "api".to_string(),
+            DevPortConfig::Resolved(ResolvedDevPortConfig {
+                env: vec![key.to_string()],
+                file_env: Some(vec![]),
+                default: 4100,
+                offset_from: None,
+                offset_base: None,
+                saturating_offset: false,
+            }),
+        )]);
+        let file_env = HashMap::from([(key.to_string(), "4200".to_string())]);
+
+        let ports = resolve_ports(&configs, &file_env).unwrap();
+        assert_eq!(ports["api"], 4100);
+    }
+
+    #[test]
+    fn validates_offset_graph_before_considering_overrides() {
+        let malformed = ResolvedDevPortConfig {
+            env: vec!["PORT_OVERRIDE".to_string()],
+            file_env: None,
+            default: 3300,
+            offset_from: Some("missing".to_string()),
+            offset_base: None,
+            saturating_offset: false,
+        };
+        let configs = HashMap::from([("web".to_string(), DevPortConfig::Resolved(malformed))]);
+        let error = validate_port_offsets(&configs).unwrap_err();
+        assert!(error.to_string().contains("missing offset_base"));
+
+        let cyclic = |next: &str| {
+            DevPortConfig::Resolved(ResolvedDevPortConfig {
+                env: vec![],
+                file_env: None,
+                default: 3000,
+                offset_from: Some(next.to_string()),
+                offset_base: Some(3000),
+                saturating_offset: false,
+            })
+        };
+        let configs = HashMap::from([
+            ("one".to_string(), cyclic("two")),
+            ("two".to_string(), cyclic("one")),
+        ]);
+        let error = validate_port_offsets(&configs).unwrap_err();
+        assert!(error.to_string().contains("cycle"));
+    }
+
+    #[test]
+    fn rejects_environment_entries_that_command_cannot_accept() {
+        let invalid_key = HashMap::from([("BAD=KEY".to_string(), "value".to_string())]);
+        assert!(validate_environment("api", &invalid_key)
+            .unwrap_err()
+            .to_string()
+            .contains("invalid environment key"));
+
+        let invalid_value = HashMap::from([("KEY".to_string(), "bad\0value".to_string())]);
+        assert!(validate_environment("api", &invalid_value)
+            .unwrap_err()
+            .to_string()
+            .contains("contains NUL"));
+    }
+}

--- a/src/dev/plan.rs
+++ b/src/dev/plan.rs
@@ -10,7 +10,7 @@ use crate::graph::TargetGraph;
 use crate::plugins::{PluginRegistry, Target};
 use crate::watch::WatchPlan;
 
-/// Fully resolved plan for one invocation of `aster dev`.
+/// Fully resolved plan for one invocation of `aster services up`.
 pub struct DevPlan {
     pub services: Vec<ServicePlan>,
     pub ports: HashMap<String, u16>,
@@ -50,14 +50,14 @@ pub fn resolve_dev_plan(
             ports
                 .get(name)
                 .copied()
-                .ok_or_else(|| anyhow!("dev control_port references unknown port '{name}'"))
+                .ok_or_else(|| anyhow!("control_port references unknown service port '{name}'"))
         })
         .transpose()?;
     let selected: HashSet<&str> = selected.iter().map(String::as_str).collect();
 
     for name in &selected {
         if !config.services.contains_key(*name) {
-            bail!("unknown dev service '{name}'");
+            bail!("unknown service '{name}'");
         }
     }
 
@@ -77,16 +77,16 @@ pub fn resolve_dev_plan(
 
         let (project_address, _) = service.target.split_once(':').ok_or_else(|| {
             anyhow!(
-                "dev service '{name}' target must use //project:target syntax: {}",
+                "service '{name}' target must use //project:target syntax: {}",
                 service.target
             )
         })?;
         let project = project_by_address.get(project_address).ok_or_else(|| {
-            anyhow!("dev service '{name}' references unknown project {project_address}")
+            anyhow!("service '{name}' references unknown project {project_address}")
         })?;
         let node = graph.get(&service.target).ok_or_else(|| {
             anyhow!(
-                "dev service '{name}' references unknown target {}",
+                "service '{name}' references unknown target {}",
                 service.target
             )
         })?;
@@ -96,14 +96,14 @@ pub fn resolve_dev_plan(
             .ok_or_else(|| anyhow!("target definition missing for {}", service.target))?;
         if !target.stream {
             bail!(
-                "dev service '{name}' target {} must set stream = true",
+                "service '{name}' target {} must set stream = true",
                 service.target
             );
         }
 
         let port = match service.port.as_deref() {
             Some(port_name) => Some(*ports.get(port_name).ok_or_else(|| {
-                anyhow!("dev service '{name}' references unknown port '{port_name}'")
+                anyhow!("service '{name}' references unknown port '{port_name}'")
             })?),
             None => None,
         };
@@ -119,7 +119,7 @@ pub fn resolve_dev_plan(
             service_env.insert(
                 key.clone(),
                 expand_template(value, port, &ports).with_context(|| {
-                    format!("invalid env value for dev service '{name}' key '{key}'")
+                    format!("invalid env value for service '{name}' key '{key}'")
                 })?,
             );
         }
@@ -131,7 +131,7 @@ pub fn resolve_dev_plan(
 
         let mut target = target.clone();
         target.command = expand_template(&target.command, port, &ports)
-            .with_context(|| format!("invalid command for dev service '{name}'"))?;
+            .with_context(|| format!("invalid command for service '{name}'"))?;
         let open_url = port.map(|port| {
             let path = service.open_path.as_deref().unwrap_or("");
             let path = if path.is_empty() || path.starts_with('/') {
@@ -147,7 +147,7 @@ pub fn resolve_dev_plan(
             graph,
             plugins,
         )
-        .with_context(|| format!("failed to build watch plan for dev service '{name}'"))?;
+        .with_context(|| format!("failed to build watch plan for service '{name}'"))?;
 
         services.push(ServicePlan {
             name: name.clone(),
@@ -162,7 +162,7 @@ pub fn resolve_dev_plan(
     }
 
     if services.is_empty() {
-        bail!("no dev services selected");
+        bail!("no services selected");
     }
 
     Ok(DevPlan {
@@ -176,7 +176,7 @@ fn validate_environment(service: &str, environment: &HashMap<String, String>) ->
     for (key, value) in environment {
         validate_environment_key(service, key)?;
         if value.contains('\0') {
-            bail!("dev service '{service}' environment value for '{key}' contains NUL");
+            bail!("service '{service}' environment value for '{key}' contains NUL");
         }
     }
     Ok(())
@@ -184,7 +184,7 @@ fn validate_environment(service: &str, environment: &HashMap<String, String>) ->
 
 fn validate_environment_key(service: &str, key: &str) -> Result<()> {
     if key.is_empty() || key.contains('=') || key.contains('\0') {
-        bail!("dev service '{service}' has invalid environment key {key:?}");
+        bail!("service '{service}' has invalid environment key {key:?}");
     }
     Ok(())
 }
@@ -294,7 +294,7 @@ fn resolve_ports(
             let mut names = pending.into_iter().collect::<Vec<_>>();
             names.sort_unstable();
             bail!(
-                "unable to resolve dev ports (unknown or cyclic offset_from): {}",
+                "unable to resolve service ports (unknown or cyclic offset_from): {}",
                 names.join(", ")
             );
         }
@@ -321,7 +321,7 @@ fn validate_port_offsets(configs: &HashMap<String, DevPortConfig>) -> Result<()>
                 break;
             };
             if !seen.insert(current) {
-                bail!("dev port offset_from cycle includes '{current}'");
+                bail!("service port offset_from cycle includes '{current}'");
             }
             if !configs.contains_key(next) {
                 bail!("port '{current}' offset_from references unknown port '{next}'");

--- a/src/dev/process.rs
+++ b/src/dev/process.rs
@@ -1,0 +1,563 @@
+use std::collections::HashMap;
+use std::process::{Child, Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{Sender, SyncSender};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+
+use crate::executor::command::parse_command;
+#[cfg(any(unix, windows))]
+use crate::executor::{register_supervised_child, unregister_supervised_child};
+use crate::plugins::Target;
+
+#[derive(Debug)]
+pub struct LogEvent {
+    pub service: String,
+    pub line: String,
+    pub stderr: bool,
+}
+
+pub struct ServiceProcess {
+    child: Child,
+    #[cfg(unix)]
+    pgid: i32,
+    stdout: Option<JoinHandle<()>>,
+    stderr: Option<JoinHandle<()>>,
+    reader_stop: Arc<AtomicBool>,
+    finished: bool,
+    #[cfg(any(unix, windows))]
+    registered: bool,
+    #[cfg(windows)]
+    job: usize,
+}
+
+impl ServiceProcess {
+    pub fn spawn(
+        service: &str,
+        target: &Target,
+        project_root: &std::path::Path,
+        env: &HashMap<String, String>,
+        log_tx: &SyncSender<LogEvent>,
+        system_tx: &Sender<LogEvent>,
+        ui: bool,
+    ) -> Result<Self> {
+        let parsed = parse_command(&target.command)?;
+        let working_dir = target.working_dir.as_deref().unwrap_or(project_root);
+        let mut command = Command::new(&parsed.program);
+        command
+            .args(&parsed.args)
+            .current_dir(working_dir)
+            .env_clear()
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        preserve_baseline_environment(&mut command);
+        command.envs(env);
+        for (name, value) in parsed.env {
+            command.env(name, value);
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+            register_supervised_child();
+        }
+        #[cfg(windows)]
+        register_supervised_child();
+
+        let mut child = command
+            .spawn()
+            .inspect_err(|_| {
+                #[cfg(any(unix, windows))]
+                unregister_supervised_child();
+            })
+            .with_context(|| format!("failed to spawn dev service '{service}'"))?;
+        #[cfg(windows)]
+        let job = assign_kill_on_close_job_and_resume(&mut child)
+            .inspect_err(|_| unregister_supervised_child())
+            .with_context(|| format!("failed to supervise dev service '{service}'"))?;
+        let stdout = child.stdout.take().context("missing service stdout")?;
+        let stderr = child.stderr.take().context("missing service stderr")?;
+        #[cfg(unix)]
+        if let Err(error) =
+            set_pipe_nonblocking(&stdout).and_then(|()| set_pipe_nonblocking(&stderr))
+        {
+            unsafe {
+                libc::kill(-(child.id() as i32), libc::SIGKILL);
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+            unregister_supervised_child();
+            return Err(error);
+        }
+        let reader_stop = Arc::new(AtomicBool::new(false));
+        let stdout_handle = spawn_reader(
+            service,
+            false,
+            stdout,
+            log_tx.clone(),
+            system_tx.clone(),
+            reader_stop.clone(),
+            ui,
+        );
+        let stderr_handle = spawn_reader(
+            service,
+            true,
+            stderr,
+            log_tx.clone(),
+            system_tx.clone(),
+            reader_stop.clone(),
+            ui,
+        );
+
+        Ok(Self {
+            #[cfg(unix)]
+            pgid: child.id() as i32,
+            child,
+            stdout: Some(stdout_handle),
+            stderr: Some(stderr_handle),
+            reader_stop,
+            finished: false,
+            #[cfg(unix)]
+            registered: true,
+            #[cfg(windows)]
+            registered: true,
+            #[cfg(windows)]
+            job,
+        })
+    }
+
+    pub fn poll(&mut self) -> Result<Option<i32>> {
+        Ok(self
+            .child
+            .try_wait()?
+            .map(|status| status.code().unwrap_or(-1)))
+    }
+
+    pub fn terminate(&mut self, grace: Duration) {
+        let deadline = Instant::now() + grace;
+        self.request_terminate();
+        self.finish_terminate(deadline);
+    }
+
+    pub fn request_terminate(&mut self) {
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(-self.pgid, libc::SIGTERM);
+        }
+        #[cfg(not(unix))]
+        {
+            #[cfg(windows)]
+            if self.job == 0 {
+                crate::windows_process::terminate_process_tree(self.child.id());
+            } else {
+                unsafe {
+                    windows_sys::Win32::System::JobObjects::TerminateJobObject(
+                        self.job as windows_sys::Win32::Foundation::HANDLE,
+                        1,
+                    );
+                }
+            }
+            #[cfg(not(windows))]
+            let _ = self.child.kill();
+        }
+    }
+
+    pub fn finish_terminate(&mut self, deadline: Instant) {
+        while Instant::now() < deadline {
+            let child_exited = self.child.try_wait().ok().flatten().is_some();
+            #[cfg(unix)]
+            let group_exited = !process_group_exists(self.pgid);
+            #[cfg(not(unix))]
+            let group_exited = child_exited;
+            if child_exited && group_exited {
+                self.finish();
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(40));
+        }
+
+        #[cfg(unix)]
+        unsafe {
+            libc::kill(-self.pgid, libc::SIGKILL);
+        }
+        #[cfg(windows)]
+        if self.job == 0 {
+            crate::windows_process::terminate_process_tree(self.child.id());
+        } else {
+            unsafe {
+                windows_sys::Win32::System::JobObjects::TerminateJobObject(
+                    self.job as windows_sys::Win32::Foundation::HANDLE,
+                    1,
+                );
+            }
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        #[cfg(unix)]
+        {
+            let force_deadline = Instant::now() + Duration::from_secs(1);
+            while process_group_exists(self.pgid) && Instant::now() < force_deadline {
+                std::thread::sleep(Duration::from_millis(25));
+            }
+        }
+        self.finish();
+    }
+
+    fn finish(&mut self) {
+        if self.finished {
+            return;
+        }
+        #[cfg(windows)]
+        let job_backed = self.job != 0;
+        #[cfg(not(windows))]
+        let job_backed = true;
+        #[cfg(windows)]
+        if !job_backed {
+            crate::windows_process::terminate_process_tree(self.child.id());
+        }
+        #[cfg(windows)]
+        if self.job != 0 {
+            unsafe {
+                windows_sys::Win32::Foundation::CloseHandle(
+                    self.job as windows_sys::Win32::Foundation::HANDLE,
+                );
+            }
+            self.job = 0;
+        }
+        if job_backed {
+            let drain_deadline = Instant::now() + Duration::from_millis(250);
+            while Instant::now() < drain_deadline
+                && (self
+                    .stdout
+                    .as_ref()
+                    .is_some_and(|handle| !handle.is_finished())
+                    || self
+                        .stderr
+                        .as_ref()
+                        .is_some_and(|handle| !handle.is_finished()))
+            {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            self.reader_stop.store(true, Ordering::SeqCst);
+            if let Some(handle) = self.stdout.take() {
+                let _ = handle.join();
+            }
+            if let Some(handle) = self.stderr.take() {
+                let _ = handle.join();
+            }
+        } else {
+            self.reader_stop.store(true, Ordering::SeqCst);
+            self.stdout.take();
+            self.stderr.take();
+        }
+        #[cfg(any(unix, windows))]
+        if self.registered {
+            unregister_supervised_child();
+            self.registered = false;
+        }
+        self.finished = true;
+    }
+}
+
+fn preserve_baseline_environment(command: &mut Command) {
+    #[cfg(unix)]
+    const BASELINE: &[&str] = &[
+        "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TMPDIR", "LANG", "LC_ALL", "TERM",
+    ];
+    #[cfg(windows)]
+    const BASELINE: &[&str] = &[
+        "PATH",
+        "SystemRoot",
+        "WINDIR",
+        "ComSpec",
+        "PATHEXT",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "APPDATA",
+        "LOCALAPPDATA",
+        "TEMP",
+        "TMP",
+        "LANG",
+    ];
+    #[cfg(not(any(unix, windows)))]
+    const BASELINE: &[&str] = &["PATH", "HOME", "TMPDIR", "TEMP", "TMP", "LANG"];
+
+    for key in BASELINE {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        }
+    }
+    for (key, value) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("LC_") {
+            command.env(key, value);
+        }
+    }
+}
+
+impl Drop for ServiceProcess {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        #[cfg(unix)]
+        let group_exists = process_group_exists(self.pgid);
+        #[cfg(not(unix))]
+        let group_exists = self.child.try_wait().ok().flatten().is_none();
+        if group_exists {
+            self.terminate(Duration::from_millis(500));
+        } else {
+            self.finish();
+        }
+    }
+}
+
+#[cfg(unix)]
+fn process_group_exists(pgid: i32) -> bool {
+    let result = unsafe { libc::kill(-pgid, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(unix)]
+fn set_pipe_nonblocking(pipe: &impl std::os::fd::AsRawFd) -> Result<()> {
+    let fd = pipe.as_raw_fd();
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags == -1 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1 {
+        anyhow::bail!(
+            "failed to make service output pipe nonblocking: {}",
+            std::io::Error::last_os_error()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn assign_kill_on_close_job_and_resume(child: &mut Child) -> Result<usize> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, JobObjectExtendedLimitInformation, SetInformationJobObject,
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    unsafe {
+        let job = windows_sys::Win32::System::JobObjects::CreateJobObjectW(
+            std::ptr::null(),
+            std::ptr::null(),
+        );
+        if job.is_null() {
+            let error = std::io::Error::last_os_error();
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("CreateJobObjectW failed: {error}");
+        }
+        let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+        info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            (&raw const info).cast(),
+            std::mem::size_of_val(&info) as u32,
+        );
+        if configured == 0 {
+            let error = std::io::Error::last_os_error();
+            windows_sys::Win32::Foundation::CloseHandle(job);
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("Windows Job Object setup failed: {error}");
+        }
+        if AssignProcessToJobObject(job, child.as_raw_handle() as _) == 0 {
+            let error = std::io::Error::last_os_error();
+            windows_sys::Win32::Foundation::CloseHandle(job);
+            if error.raw_os_error()
+                == Some(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as i32)
+            {
+                if let Err(error) = resume_process(child.id()) {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(error);
+                }
+                return Ok(0);
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+            anyhow::bail!("Windows Job Object assignment failed: {error}");
+        }
+        if let Err(error) = resume_process(child.id()) {
+            windows_sys::Win32::Foundation::CloseHandle(job);
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(error);
+        }
+        Ok(job as usize)
+    }
+}
+
+#[cfg(windows)]
+fn resume_process(process_id: u32) -> Result<()> {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows_sys::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            anyhow::bail!(
+                "failed to enumerate suspended process threads: {}",
+                std::io::Error::last_os_error()
+            );
+        }
+        let mut entry: THREADENTRY32 = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<THREADENTRY32>() as u32;
+        let mut has_entry = Thread32First(snapshot, &mut entry) != 0;
+        let mut resumed = false;
+        while has_entry {
+            if entry.th32OwnerProcessID == process_id {
+                let thread = OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID);
+                if thread.is_null() {
+                    let error = std::io::Error::last_os_error();
+                    CloseHandle(snapshot);
+                    anyhow::bail!("failed to open suspended process thread: {error}");
+                }
+                let result = ResumeThread(thread);
+                CloseHandle(thread);
+                if result == u32::MAX {
+                    let error = std::io::Error::last_os_error();
+                    CloseHandle(snapshot);
+                    anyhow::bail!("failed to resume service process: {error}");
+                }
+                resumed = true;
+                break;
+            }
+            has_entry = Thread32Next(snapshot, &mut entry) != 0;
+        }
+        CloseHandle(snapshot);
+        if !resumed {
+            anyhow::bail!("suspended service process had no discoverable primary thread");
+        }
+    }
+    Ok(())
+}
+
+fn spawn_reader<R: std::io::Read + Send + 'static>(
+    service: &str,
+    stderr: bool,
+    reader: R,
+    tx: SyncSender<LogEvent>,
+    system_tx: Sender<LogEvent>,
+    stop: Arc<AtomicBool>,
+    ui: bool,
+) -> JoinHandle<()> {
+    let service = service.to_string();
+    std::thread::spawn(move || {
+        let mut reader = reader;
+        let mut pending = Vec::new();
+        let mut chunk = [0u8; 8192];
+        let mut drop_reported = false;
+        loop {
+            if stop.load(Ordering::SeqCst) {
+                break;
+            }
+            let read = match reader.read(&mut chunk) {
+                Ok(read) => read,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(20));
+                    continue;
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            };
+            if read == 0 {
+                if !pending.is_empty() {
+                    forward_log_line(
+                        &service,
+                        stderr,
+                        &pending,
+                        &tx,
+                        &system_tx,
+                        ui,
+                        &mut drop_reported,
+                    );
+                }
+                break;
+            }
+            pending.extend_from_slice(&chunk[..read]);
+            while let Some(newline) = pending.iter().position(|byte| *byte == b'\n') {
+                let mut line = pending.drain(..=newline).collect::<Vec<_>>();
+                while matches!(line.last(), Some(b'\n' | b'\r')) {
+                    line.pop();
+                }
+                forward_log_line(
+                    &service,
+                    stderr,
+                    &line,
+                    &tx,
+                    &system_tx,
+                    ui,
+                    &mut drop_reported,
+                );
+            }
+            const MAX_PENDING_LINE: usize = 64 * 1024;
+            while pending.len() >= MAX_PENDING_LINE {
+                let mut bounded = pending.drain(..MAX_PENDING_LINE).collect::<Vec<_>>();
+                bounded.extend_from_slice(b" [aster: long line continued]");
+                forward_log_line(
+                    &service,
+                    stderr,
+                    &bounded,
+                    &tx,
+                    &system_tx,
+                    ui,
+                    &mut drop_reported,
+                );
+            }
+        }
+    })
+}
+
+fn forward_log_line(
+    service: &str,
+    stderr: bool,
+    bytes: &[u8],
+    tx: &SyncSender<LogEvent>,
+    system_tx: &Sender<LogEvent>,
+    ui: bool,
+    drop_reported: &mut bool,
+) {
+    let line = String::from_utf8_lossy(bytes).into_owned();
+    if !ui {
+        let stream = if stderr { "!" } else { "|" };
+        println!("[{service}] {stream} {line}");
+        return;
+    }
+    let event = LogEvent {
+        service: service.to_string(),
+        line,
+        stderr,
+    };
+    match tx.try_send(event) {
+        Ok(()) => *drop_reported = false,
+        Err(std::sync::mpsc::TrySendError::Full(_)) => {
+            if !*drop_reported {
+                let _ = system_tx.send(LogEvent {
+                    service: service.to_string(),
+                    line: "[aster] service output omitted while the UI was busy".to_string(),
+                    stderr: true,
+                });
+                *drop_reported = true;
+            }
+        }
+        Err(std::sync::mpsc::TrySendError::Disconnected(_)) => {}
+    }
+}

--- a/src/dev/process.rs
+++ b/src/dev/process.rs
@@ -80,11 +80,11 @@ impl ServiceProcess {
                 #[cfg(any(unix, windows))]
                 unregister_supervised_child();
             })
-            .with_context(|| format!("failed to spawn dev service '{service}'"))?;
+            .with_context(|| format!("failed to spawn service '{service}'"))?;
         #[cfg(windows)]
         let job = assign_kill_on_close_job_and_resume(&mut child)
             .inspect_err(|_| unregister_supervised_child())
-            .with_context(|| format!("failed to supervise dev service '{service}'"))?;
+            .with_context(|| format!("failed to supervise service '{service}'"))?;
         let stdout = child.stdout.take().context("missing service stdout")?;
         let stderr = child.stderr.take().context("missing service stderr")?;
         #[cfg(unix)]

--- a/src/dev/runner.rs
+++ b/src/dev/runner.rs
@@ -1,0 +1,980 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use crossterm::event::{self, Event, KeyEventKind};
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
+
+use crate::cli::OutputMode;
+use crate::config::WorkspaceConfig;
+use crate::discovery::DiscoveredProject;
+use crate::executor::{self, Executor};
+use crate::graph::TargetGraph;
+use crate::watch::WorkspaceIgnore;
+
+use super::dashboard::{Dashboard, DashboardAction, ServiceState, TerminalGuard};
+use super::plan::{DevPlan, ServicePlan};
+use super::process::{LogEvent, ServiceProcess};
+
+pub struct DevOptions {
+    pub watch: bool,
+    pub ui: bool,
+    pub dry_run: bool,
+    pub use_cache: bool,
+}
+
+struct Runtime {
+    process: Option<ServiceProcess>,
+}
+
+enum StartOutcome {
+    Running(ServiceProcess),
+    Stopped,
+}
+
+struct StartResult {
+    service: String,
+    outcome: StartOutcome,
+}
+
+pub fn run_dev(
+    workspace_root: &Path,
+    projects: Vec<DiscoveredProject>,
+    graph: TargetGraph,
+    plan: DevPlan,
+    config: &WorkspaceConfig,
+    options: DevOptions,
+) -> Result<()> {
+    print_plan(&plan);
+    if options.dry_run {
+        return Ok(());
+    }
+
+    let shutdown = executor::install_signal_handler();
+    executor::request_graceful_signal_handling();
+    let ignore = WorkspaceIgnore::build(&config.watch)?;
+    let (log_tx, log_rx) = mpsc::sync_channel(4000);
+    let (system_tx, system_rx) = mpsc::channel();
+    let control = plan.control_port.map(ControlServer::start).transpose()?;
+    let (watch_rx, _watcher) = if options.watch {
+        let (rx, watcher) = start_watcher(&plan)?;
+        (Some(rx), Some(watcher))
+    } else {
+        (None, None)
+    };
+    let mut dashboard = Dashboard::new(&plan.services);
+    let mut runtimes: HashMap<String, Runtime> = plan
+        .services
+        .iter()
+        .map(|service| (service.name.clone(), Runtime { process: None }))
+        .collect();
+    let projects = Arc::new(projects);
+    let (start_tx, start_rx) = mpsc::channel::<StartResult>();
+    let mut active_start: Option<(String, std::thread::JoinHandle<()>)> = None;
+    let mut pending_starts = plan
+        .services
+        .iter()
+        .map(|service| (service.name.clone(), "initial start".to_string()))
+        .collect::<VecDeque<_>>();
+
+    let workspace_header = workspace_header(workspace_root);
+    let mut terminal = options.ui.then(TerminalGuard::enter).transpose()?;
+    let mut needs_draw = true;
+    // Events queued while initial prerequisites start are processed after this
+    // point. Suppress only configured generated paths; genuine source edits
+    // remain eligible for a follow-up restart.
+    let mut suppress_until = Instant::now() + Duration::from_millis(700);
+    let watch_debounce = Duration::from_millis(config.watch.debounce_ms.unwrap_or(300));
+    let mut pending_watch_paths = Vec::new();
+    let mut watch_deadline: Option<Instant> = None;
+    let mut quitting = false;
+
+    let run_result = (|| -> Result<()> {
+        while !quitting
+            && !shutdown.load(Ordering::SeqCst)
+            && !control
+                .as_ref()
+                .is_some_and(|control| control.shutdown.load(Ordering::SeqCst))
+        {
+            needs_draw |= drain_logs(&log_rx, &system_rx, &mut dashboard, options.ui);
+
+            while let Ok(result) = start_rx.try_recv() {
+                if let Some((name, handle)) = active_start.take() {
+                    debug_assert_eq!(name, result.service);
+                    let _ = handle.join();
+                }
+                let runtime = runtimes
+                    .get_mut(&result.service)
+                    .expect("start result service exists");
+                match result.outcome {
+                    StartOutcome::Running(process) => {
+                        runtime.process = Some(process);
+                        dashboard.set_state(&result.service, ServiceState::Running);
+                    }
+                    StartOutcome::Stopped => {
+                        dashboard.set_state(&result.service, ServiceState::Stopped);
+                    }
+                }
+                suppress_until = Instant::now() + Duration::from_millis(700);
+                needs_draw = true;
+            }
+            if active_start.is_none() {
+                if let Some((name, reason)) = pending_starts.pop_front() {
+                    let service = plan
+                        .services
+                        .iter()
+                        .find(|service| service.name == name)
+                        .expect("queued service exists");
+                    let handle = begin_start_service(
+                        service,
+                        workspace_root,
+                        projects.clone(),
+                        &graph,
+                        options.use_cache,
+                        options.ui,
+                        &log_tx,
+                        &system_tx,
+                        &mut dashboard,
+                        runtimes.get_mut(&name).expect("runtime exists"),
+                        &reason,
+                        start_tx.clone(),
+                    );
+                    active_start = Some((name, handle));
+                    needs_draw = true;
+                }
+            }
+
+            for service in &plan.services {
+                let runtime = runtimes.get_mut(&service.name).expect("runtime exists");
+                let exited = runtime
+                    .process
+                    .as_mut()
+                    .and_then(|process| process.poll().ok().flatten());
+                if let Some(code) = exited {
+                    runtime.process.take();
+                    dashboard.set_state(&service.name, ServiceState::Stopped);
+                    emit_system(
+                        &system_tx,
+                        &service.name,
+                        format!("process exited with code {code}"),
+                        true,
+                    );
+                    needs_draw = true;
+                }
+            }
+
+            if let Some(rx) = &watch_rx {
+                while let Ok(event) = rx.try_recv() {
+                    match event {
+                        Ok(event) if is_meaningful_event(&event.kind) => {
+                            pending_watch_paths.extend(event.paths);
+                            watch_deadline.get_or_insert_with(|| Instant::now() + watch_debounce);
+                        }
+                        Ok(_) => {}
+                        Err(error) => eprintln!("[dev] watcher error: {error}"),
+                    }
+                }
+                if watch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+                    let changed = std::mem::take(&mut pending_watch_paths);
+                    watch_deadline = None;
+                    let affected = affected_services(
+                        &plan,
+                        &graph,
+                        workspace_root,
+                        &ignore,
+                        &changed,
+                        active_start.is_some() || Instant::now() < suppress_until,
+                    );
+                    for name in affected {
+                        if plan.services.iter().any(|service| service.name == name) {
+                            queue_restart(
+                                &mut pending_starts,
+                                &name,
+                                "watched dependency changed",
+                                &system_tx,
+                                &mut dashboard,
+                            );
+                            suppress_until = Instant::now() + Duration::from_millis(700);
+                            needs_draw = true;
+                        }
+                    }
+                }
+            }
+
+            if let Some(rx) = control.as_ref().map(|control| &control.rx) {
+                while let Ok(request) = rx.try_recv() {
+                    let response = match request.command.as_str() {
+                        "status" => {
+                            let services = plan
+                                .services
+                                .iter()
+                                .map(|service| {
+                                    let running = runtimes
+                                        .get(&service.name)
+                                        .and_then(|runtime| runtime.process.as_ref())
+                                        .is_some();
+                                    (
+                                        service.name.clone(),
+                                        serde_json::Value::String(
+                                            if running { "running" } else { "stopped" }.to_string(),
+                                        ),
+                                    )
+                                })
+                                .collect::<serde_json::Map<_, _>>();
+                            serde_json::json!({"ok": true, "services": services})
+                        }
+                        "list_services" => serde_json::json!({
+                            "ok": true,
+                            "services": plan.services.iter().map(|service| &service.name).collect::<Vec<_>>()
+                        }),
+                        "restart" => match request.service.as_deref() {
+                            Some(name) => {
+                                match plan.services.iter().find(|service| service.name == name) {
+                                    Some(_) => {
+                                        queue_restart(
+                                            &mut pending_starts,
+                                            name,
+                                            "control socket restart",
+                                            &system_tx,
+                                            &mut dashboard,
+                                        );
+                                        needs_draw = true;
+                                        serde_json::json!({"ok": true, "queued": true})
+                                    }
+                                    None => serde_json::json!({
+                                        "ok": false,
+                                        "error": format!("unknown service: {name}")
+                                    }),
+                                }
+                            }
+                            None => serde_json::json!({
+                                "ok": false,
+                                "error": "restart requires 'service' field"
+                            }),
+                        },
+                        "restart_all" => {
+                            for service in &plan.services {
+                                if shutdown.load(Ordering::SeqCst) {
+                                    break;
+                                }
+                                queue_restart(
+                                    &mut pending_starts,
+                                    &service.name,
+                                    "control socket restart_all",
+                                    &system_tx,
+                                    &mut dashboard,
+                                );
+                            }
+                            needs_draw = true;
+                            serde_json::json!({"ok": true, "queued": true})
+                        }
+                        "shutdown" => {
+                            quitting = true;
+                            serde_json::json!({"ok": true})
+                        }
+                        other => serde_json::json!({
+                            "ok": false,
+                            "error": format!("unknown command: {other}")
+                        }),
+                    };
+                    let _ = request.reply.send(response);
+                }
+            }
+
+            if let Some(guard) = terminal.as_mut() {
+                if needs_draw {
+                    dashboard.draw(
+                        &mut guard.terminal,
+                        &workspace_header,
+                        control
+                            .as_ref()
+                            .and_then(|control| control.token_path.to_str()),
+                    )?;
+                    needs_draw = false;
+                }
+                if event::poll(Duration::from_millis(75))? {
+                    match event::read()? {
+                        Event::Key(key)
+                            if matches!(key.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+                        {
+                            match dashboard.handle_key(key) {
+                                DashboardAction::Quit => break,
+                                DashboardAction::Restart(name) => {
+                                    queue_restart(
+                                        &mut pending_starts,
+                                        &name,
+                                        "manual restart",
+                                        &system_tx,
+                                        &mut dashboard,
+                                    );
+                                    suppress_until = Instant::now() + Duration::from_millis(700);
+                                    needs_draw = true;
+                                }
+                                DashboardAction::Open => {
+                                    if let Some(url) = dashboard.active_url() {
+                                        if let Err(error) = open_url(url) {
+                                            let active = dashboard.active_name().to_string();
+                                            dashboard.push_system(
+                                                &active,
+                                                format!("failed to open browser: {error}"),
+                                            );
+                                        }
+                                    }
+                                    needs_draw = true;
+                                }
+                                DashboardAction::Draw => needs_draw = true,
+                                DashboardAction::None => {}
+                            }
+                        }
+                        Event::Resize(_, _) => needs_draw = true,
+                        _ => {}
+                    }
+                }
+            } else {
+                std::thread::sleep(Duration::from_millis(75));
+            }
+        }
+        Ok(())
+    })();
+
+    drop(terminal);
+    eprintln!("[dev] shutting down services...");
+    executor::request_shutdown();
+    pending_starts.clear();
+    if let Some((_, handle)) = active_start.take() {
+        let _ = handle.join();
+    }
+    let mut shutdown_processes = Vec::new();
+    while let Ok(result) = start_rx.try_recv() {
+        if let StartOutcome::Running(process) = result.outcome {
+            shutdown_processes.push(process);
+        }
+    }
+    for service in plan.services.iter().rev() {
+        if let Some(process) = runtimes
+            .get_mut(&service.name)
+            .and_then(|runtime| runtime.process.take())
+        {
+            shutdown_processes.push(process);
+        }
+    }
+    let shutdown_deadline = Instant::now() + Duration::from_secs(3);
+    for process in &mut shutdown_processes {
+        process.request_terminate();
+    }
+    for process in &mut shutdown_processes {
+        process.finish_terminate(shutdown_deadline);
+    }
+    drain_logs(&log_rx, &system_rx, &mut dashboard, false);
+    drop(control);
+    if let Some(signal) = executor::shutdown_signal() {
+        std::process::exit(128 + signal);
+    }
+    run_result?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn begin_start_service(
+    service: &ServicePlan,
+    workspace_root: &Path,
+    projects: Arc<Vec<DiscoveredProject>>,
+    graph: &TargetGraph,
+    use_cache: bool,
+    ui: bool,
+    log_tx: &std::sync::mpsc::SyncSender<LogEvent>,
+    system_tx: &std::sync::mpsc::Sender<LogEvent>,
+    dashboard: &mut Dashboard,
+    runtime: &mut Runtime,
+    reason: &str,
+    result_tx: std::sync::mpsc::Sender<StartResult>,
+) -> std::thread::JoinHandle<()> {
+    if let Some(mut process) = runtime.process.take() {
+        process.terminate(Duration::from_secs(3));
+    }
+    let state = if reason == "initial start" {
+        ServiceState::Starting
+    } else {
+        ServiceState::Restarting
+    };
+    dashboard.set_state(&service.name, state);
+    if reason != "initial start" {
+        emit_system(
+            system_tx,
+            &service.name,
+            format!("restart requested: {reason}"),
+            false,
+        );
+    }
+    emit_system(
+        system_tx,
+        &service.name,
+        format!("running prerequisites for {}", service.target_address),
+        false,
+    );
+    let mut prerequisites = HashSet::new();
+    collect_non_stream_dependencies(
+        &service.target_address,
+        graph,
+        &service.watch,
+        &mut prerequisites,
+    );
+    let service_name = service.name.clone();
+    let target_address = service.target_address.clone();
+    let target = service.target.clone();
+    let project_root = service.project_root.clone();
+    let env = service.env.clone();
+    let workspace_root = workspace_root.to_path_buf();
+    let log_tx = log_tx.clone();
+    let system_tx = system_tx.clone();
+    std::thread::spawn(move || {
+        let prerequisite_run =
+            run_prerequisites(&prerequisites, &workspace_root, &projects, use_cache);
+        for (stderr, line) in prerequisite_run.lines {
+            let _ = system_tx.send(LogEvent {
+                service: service_name.clone(),
+                line,
+                stderr,
+            });
+        }
+        if !prerequisite_run.failures.is_empty() {
+            emit_system(
+                &system_tx,
+                &service_name,
+                format!(
+                    "prerequisite failed: {}",
+                    prerequisite_run.failures.join(", ")
+                ),
+                true,
+            );
+            let _ = result_tx.send(StartResult {
+                service: service_name,
+                outcome: StartOutcome::Stopped,
+            });
+            return;
+        }
+        if executor::shutdown_requested() {
+            emit_system(
+                &system_tx,
+                &service_name,
+                "shutdown requested; service start skipped".to_string(),
+                false,
+            );
+            let _ = result_tx.send(StartResult {
+                service: service_name,
+                outcome: StartOutcome::Stopped,
+            });
+            return;
+        }
+        emit_system(
+            &system_tx,
+            &service_name,
+            format!("starting {target_address}"),
+            false,
+        );
+        let outcome = match ServiceProcess::spawn(
+            &service_name,
+            &target,
+            &project_root,
+            &env,
+            &log_tx,
+            &system_tx,
+            ui,
+        ) {
+            Ok(process) => StartOutcome::Running(process),
+            Err(error) => {
+                emit_system(
+                    &system_tx,
+                    &service_name,
+                    format!("start failed: {error:#}"),
+                    true,
+                );
+                StartOutcome::Stopped
+            }
+        };
+        let _ = result_tx.send(StartResult {
+            service: service_name,
+            outcome,
+        });
+    })
+}
+
+fn queue_restart(
+    pending: &mut VecDeque<(String, String)>,
+    service: &str,
+    reason: &str,
+    system_tx: &std::sync::mpsc::Sender<LogEvent>,
+    dashboard: &mut Dashboard,
+) {
+    if let Some((_, queued_reason)) = pending.iter_mut().find(|(name, _)| name == service) {
+        *queued_reason = reason.to_string();
+        return;
+    }
+    pending.push_back((service.to_string(), reason.to_string()));
+    dashboard.set_state(service, ServiceState::Restarting);
+    emit_system(
+        system_tx,
+        service,
+        format!("restart queued: {reason}"),
+        false,
+    );
+}
+
+struct PrerequisiteRun {
+    lines: Vec<(bool, String)>,
+    failures: Vec<String>,
+}
+
+fn run_prerequisites(
+    prerequisites: &HashSet<String>,
+    workspace_root: &Path,
+    projects: &[DiscoveredProject],
+    use_cache: bool,
+) -> PrerequisiteRun {
+    if prerequisites.is_empty() {
+        return PrerequisiteRun {
+            lines: Vec::new(),
+            failures: Vec::new(),
+        };
+    }
+
+    let refs = projects.iter().collect::<Vec<_>>();
+    let results = Executor::with_all_options(workspace_root, OutputMode::Quiet, true, use_cache)
+        .with_null_stdin()
+        .execute_targets(prerequisites, &refs, true);
+    let mut lines = Vec::new();
+    for result in &results {
+        let stderr = !result.success;
+        lines.push((
+            stderr,
+            format!(
+                "[{}] {}",
+                if result.cached {
+                    "cached"
+                } else if result.success {
+                    "ok"
+                } else {
+                    "failed"
+                },
+                result.address
+            ),
+        ));
+        lines.extend(
+            result
+                .output
+                .lines()
+                .map(|line| (stderr, format!("[{}] {line}", result.address))),
+        );
+    }
+    let failures = results
+        .iter()
+        .filter(|result| !result.success && !result.skipped)
+        .map(|result| result.address.clone())
+        .collect::<Vec<_>>();
+    PrerequisiteRun { lines, failures }
+}
+
+fn collect_non_stream_dependencies(
+    address: &str,
+    graph: &TargetGraph,
+    plan: &crate::watch::WatchPlan,
+    output: &mut HashSet<String>,
+) {
+    for dependency in graph.dependencies(address) {
+        let is_stream = plan
+            .targets
+            .iter()
+            .any(|target| target.address == dependency.address && target.stream);
+        let should_recurse = is_stream || output.insert(dependency.address.clone());
+        if should_recurse {
+            collect_non_stream_dependencies(&dependency.address, graph, plan, output);
+        }
+    }
+}
+
+fn start_watcher(
+    plan: &DevPlan,
+) -> Result<(Receiver<notify::Result<notify::Event>>, RecommendedWatcher)> {
+    let (tx, rx) = mpsc::channel();
+    let mut watcher = notify::recommended_watcher(move |event| {
+        let _ = tx.send(event);
+    })
+    .context("failed to create dev file watcher")?;
+    let mut roots = plan
+        .services
+        .iter()
+        .flat_map(|service| service.watch.watch_roots.iter().cloned())
+        .collect::<Vec<_>>();
+    roots.sort();
+    roots.dedup();
+    for root in roots {
+        watcher
+            .watch(&root, RecursiveMode::Recursive)
+            .with_context(|| format!("failed to watch {}", root.display()))?;
+    }
+    Ok((rx, watcher))
+}
+
+fn affected_services(
+    plan: &DevPlan,
+    graph: &TargetGraph,
+    workspace_root: &Path,
+    ignore: &WorkspaceIgnore,
+    paths: &[PathBuf],
+    suppress_generated: bool,
+) -> Vec<String> {
+    let mut affected = HashSet::new();
+    for service in &plan.services {
+        for path in paths {
+            let relative = path.strip_prefix(workspace_root).unwrap_or(path);
+            if ignore.is_ignored(relative) {
+                continue;
+            }
+            if suppress_generated && ignore.is_suppressed(relative) {
+                continue;
+            }
+            let owners = service.watch.owners_of(path);
+            let primary = service.watch.primary_set(&owners, graph);
+            if primary.contains(&service.target_address) {
+                affected.insert(service.name.clone());
+            }
+        }
+    }
+    let mut affected = affected.into_iter().collect::<Vec<_>>();
+    affected.sort_by_key(|name| {
+        plan.services
+            .iter()
+            .position(|service| &service.name == name)
+            .unwrap_or(usize::MAX)
+    });
+    affected
+}
+
+fn is_meaningful_event(kind: &notify::EventKind) -> bool {
+    matches!(
+        kind,
+        notify::EventKind::Create(_) | notify::EventKind::Modify(_) | notify::EventKind::Remove(_)
+    )
+}
+
+fn drain_logs(
+    process_rx: &Receiver<LogEvent>,
+    system_rx: &Receiver<LogEvent>,
+    dashboard: &mut Dashboard,
+    ui: bool,
+) -> bool {
+    let mut consumed = false;
+    for rx in [system_rx, process_rx] {
+        while let Ok(event) = rx.try_recv() {
+            consumed = true;
+            if !ui {
+                let stream = if event.stderr { "!" } else { "|" };
+                println!("[{}] {stream} {}", event.service, event.line);
+            }
+            dashboard.push_log(event);
+        }
+    }
+    consumed
+}
+
+fn emit_system(
+    tx: &std::sync::mpsc::Sender<LogEvent>,
+    service: &str,
+    line: impl Into<String>,
+    stderr: bool,
+) {
+    let _ = tx.send(LogEvent {
+        service: service.to_string(),
+        line: line.into(),
+        stderr,
+    });
+}
+
+fn print_plan(plan: &DevPlan) {
+    eprintln!("[dev] {} service(s)", plan.services.len());
+    for service in &plan.services {
+        let port = service
+            .port
+            .map(|port| format!(" :{port}"))
+            .unwrap_or_default();
+        eprintln!(
+            "[dev]   {}{port} -> {}",
+            service.name, service.target_address
+        );
+    }
+    if let Some(port) = plan.control_port {
+        eprintln!("[dev]   control :{port}");
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct WireControlRequest {
+    command: String,
+    service: Option<String>,
+    token: Option<String>,
+}
+
+struct ControlRequest {
+    command: String,
+    service: Option<String>,
+    reply: SyncSender<serde_json::Value>,
+}
+
+struct ControlServer {
+    rx: Receiver<ControlRequest>,
+    stop: Arc<AtomicBool>,
+    shutdown: Arc<AtomicBool>,
+    handles: Vec<std::thread::JoinHandle<()>>,
+    token_path: PathBuf,
+}
+
+impl ControlServer {
+    fn start(port: u16) -> Result<Self> {
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind(("127.0.0.1", port))
+            .with_context(|| format!("failed to bind dev control socket on 127.0.0.1:{port}"))?;
+        listener.set_nonblocking(true)?;
+        let (token, token_path) = create_control_token(port)?;
+        eprintln!("[dev]   control token {}", token_path.display());
+        let stop = Arc::new(AtomicBool::new(false));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let (tx, rx) = mpsc::channel();
+        let (connection_tx, connection_rx) = crossbeam_channel::bounded::<std::net::TcpStream>(32);
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let connections = connection_rx.clone();
+            let tx = tx.clone();
+            let token = token.clone();
+            let stop = stop.clone();
+            let shutdown = shutdown.clone();
+            handles.push(std::thread::spawn(move || {
+                while !stop.load(Ordering::SeqCst) {
+                    match connections.recv_timeout(Duration::from_millis(100)) {
+                        Ok(stream) => {
+                            handle_control_connection(stream, &token, &tx, &stop, &shutdown);
+                        }
+                        Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
+                        Err(crossbeam_channel::RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            }));
+        }
+        let thread_stop = stop.clone();
+        let handle = std::thread::spawn(move || {
+            use std::io::Write;
+
+            while !thread_stop.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((stream, _)) => match connection_tx.try_send(stream) {
+                        Ok(()) => {}
+                        Err(crossbeam_channel::TrySendError::Full(mut stream)) => {
+                            let _ = writeln!(
+                                stream,
+                                "{}",
+                                serde_json::json!({
+                                    "ok": false,
+                                    "error": "control server busy"
+                                })
+                            );
+                        }
+                        Err(crossbeam_channel::TrySendError::Disconnected(_)) => break,
+                    },
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(50));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        handles.push(handle);
+        Ok(Self {
+            rx,
+            stop,
+            shutdown,
+            handles,
+            token_path,
+        })
+    }
+}
+
+impl Drop for ControlServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        for handle in self.handles.drain(..) {
+            let _ = handle.join();
+        }
+        let _ = std::fs::remove_file(&self.token_path);
+    }
+}
+
+fn handle_control_connection(
+    mut stream: std::net::TcpStream,
+    token: &str,
+    tx: &std::sync::mpsc::Sender<ControlRequest>,
+    stop: &AtomicBool,
+    shutdown: &AtomicBool,
+) {
+    use std::io::{BufRead, BufReader, Read, Write};
+
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+    let mut line = String::new();
+    let parsed = BufReader::new(&stream)
+        .take(64 * 1024 + 1)
+        .read_line(&mut line)
+        .ok()
+        .filter(|bytes| *bytes <= 64 * 1024)
+        .and_then(|_| serde_json::from_str::<WireControlRequest>(&line).ok());
+    let response = match parsed {
+        Some(parsed)
+            if is_state_changing_control_command(&parsed.command)
+                && parsed.token.as_deref() != Some(token) =>
+        {
+            serde_json::json!({
+                "ok": false,
+                "error": "valid control token required"
+            })
+        }
+        Some(parsed) if parsed.command == "shutdown" => {
+            shutdown.store(true, Ordering::SeqCst);
+            executor::request_shutdown();
+            serde_json::json!({"ok": true})
+        }
+        Some(parsed) => {
+            let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+            let request = ControlRequest {
+                command: parsed.command,
+                service: parsed.service,
+                reply: reply_tx,
+            };
+            if tx.send(request).is_err() {
+                serde_json::json!({"ok": false, "error": "launcher stopped"})
+            } else {
+                loop {
+                    if stop.load(Ordering::SeqCst) {
+                        break serde_json::json!({
+                            "ok": false,
+                            "error": "launcher stopped"
+                        });
+                    }
+                    match reply_rx.recv_timeout(Duration::from_millis(100)) {
+                        Ok(response) => break response,
+                        Err(mpsc::RecvTimeoutError::Timeout) => continue,
+                        Err(mpsc::RecvTimeoutError::Disconnected) => {
+                            break serde_json::json!({
+                                "ok": false,
+                                "error": "launcher stopped"
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        None => serde_json::json!({"ok": false, "error": "invalid json"}),
+    };
+    let _ = writeln!(stream, "{response}");
+}
+
+fn is_state_changing_control_command(command: &str) -> bool {
+    matches!(command, "restart" | "restart_all" | "shutdown")
+}
+
+fn create_control_token(port: u16) -> Result<(String, PathBuf)> {
+    use std::fs::OpenOptions;
+    use std::io::Write;
+
+    let mut random = [0u8; 32];
+    getrandom::fill(&mut random)
+        .map_err(|error| anyhow::anyhow!("failed to generate dev control token: {error}"))?;
+    let token = random
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let unique = random[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let path = std::env::temp_dir().join(format!(
+        "aster-dev-{port}-{}-{unique}.token",
+        std::process::id()
+    ));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&path)
+        .with_context(|| format!("failed to create control token file {}", path.display()))?;
+    file.write_all(token.as_bytes())?;
+    Ok((token, path))
+}
+
+fn workspace_header(root: &Path) -> String {
+    let branch = Command::new("git")
+        .args(["branch", "--show-current"])
+        .current_dir(root)
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+        .filter(|branch| !branch.is_empty())
+        .unwrap_or_else(|| "detached".to_string());
+    format!("{}  ·  {branch}", root.display())
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn open_url(url: &str) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    let program = "open";
+    #[cfg(target_os = "linux")]
+    let program = "xdg-open";
+    let mut child = Command::new(program)
+        .arg(url)
+        .spawn()
+        .with_context(|| format!("failed to open {url}"))?;
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn open_url(url: &str) -> Result<()> {
+    use windows_sys::Win32::UI::Shell::ShellExecuteW;
+    use windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
+
+    let operation = "open\0".encode_utf16().collect::<Vec<_>>();
+    let url = url
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let result = unsafe {
+        ShellExecuteW(
+            std::ptr::null_mut(),
+            operation.as_ptr(),
+            url.as_ptr(),
+            std::ptr::null(),
+            std::ptr::null(),
+            SW_SHOWNORMAL,
+        )
+    };
+    if result as usize <= 32 {
+        anyhow::bail!("failed to open URL (ShellExecuteW returned {result:?})");
+    }
+    Ok(())
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+fn open_url(_url: &str) -> Result<()> {
+    Err(anyhow::anyhow!(
+        "opening a browser is unsupported on this platform"
+    ))
+}

--- a/src/dev/runner.rs
+++ b/src/dev/runner.rs
@@ -327,7 +327,53 @@ pub fn run_dev(
                                     }
                                     needs_draw = true;
                                 }
+                                DashboardAction::ToggleMouse(enabled) => {
+                                    guard.set_mouse_capture(enabled)?;
+                                    needs_draw = true;
+                                }
                                 DashboardAction::Draw => needs_draw = true,
+                                DashboardAction::None => {}
+                            }
+                        }
+                        Event::Mouse(mouse) => {
+                            let size = guard.terminal.size()?;
+                            let control_token_path = control
+                                .as_ref()
+                                .and_then(|control| control.token_path.to_str());
+                            match dashboard.handle_mouse(
+                                mouse,
+                                ratatui::layout::Rect::new(0, 0, size.width, size.height),
+                                control_token_path,
+                            ) {
+                                DashboardAction::Open => {
+                                    if let Some(url) = dashboard.active_url() {
+                                        if let Err(error) = open_url(url) {
+                                            let active = dashboard.active_name().to_string();
+                                            dashboard.push_system(
+                                                &active,
+                                                format!("failed to open browser: {error}"),
+                                            );
+                                        }
+                                    }
+                                    needs_draw = true;
+                                }
+                                DashboardAction::Draw => needs_draw = true,
+                                DashboardAction::ToggleMouse(enabled) => {
+                                    guard.set_mouse_capture(enabled)?;
+                                    needs_draw = true;
+                                }
+                                DashboardAction::Restart(name) => {
+                                    queue_restart(
+                                        &mut pending_starts,
+                                        &name,
+                                        "manual restart",
+                                        &system_tx,
+                                        &mut dashboard,
+                                    );
+                                    suppress_until = Instant::now() + Duration::from_millis(700);
+                                    needs_draw = true;
+                                }
+                                DashboardAction::Quit => quitting = true,
                                 DashboardAction::None => {}
                             }
                         }

--- a/src/dev/runner.rs
+++ b/src/dev/runner.rs
@@ -737,8 +737,9 @@ impl ControlServer {
     fn start(port: u16) -> Result<Self> {
         use std::net::TcpListener;
 
-        let listener = TcpListener::bind(("127.0.0.1", port))
-            .with_context(|| format!("failed to bind services control socket on 127.0.0.1:{port}"))?;
+        let listener = TcpListener::bind(("127.0.0.1", port)).with_context(|| {
+            format!("failed to bind services control socket on 127.0.0.1:{port}")
+        })?;
         listener.set_nonblocking(true)?;
         let (token, token_path) = create_control_token(port)?;
         eprintln!("[services]   control token {}", token_path.display());

--- a/src/dev/runner.rs
+++ b/src/dev/runner.rs
@@ -176,7 +176,7 @@ pub fn run_dev(
                             watch_deadline.get_or_insert_with(|| Instant::now() + watch_debounce);
                         }
                         Ok(_) => {}
-                        Err(error) => eprintln!("[dev] watcher error: {error}"),
+                        Err(error) => eprintln!("[services] watcher error: {error}"),
                     }
                 }
                 if watch_deadline.is_some_and(|deadline| Instant::now() >= deadline) {
@@ -343,7 +343,7 @@ pub fn run_dev(
     })();
 
     drop(terminal);
-    eprintln!("[dev] shutting down services...");
+    eprintln!("[services] shutting down services...");
     executor::request_shutdown();
     pending_starts.clear();
     if let Some((_, handle)) = active_start.take() {
@@ -604,7 +604,7 @@ fn start_watcher(
     let mut watcher = notify::recommended_watcher(move |event| {
         let _ = tx.send(event);
     })
-    .context("failed to create dev file watcher")?;
+    .context("failed to create services file watcher")?;
     let mut roots = plan
         .services
         .iter()
@@ -696,19 +696,19 @@ fn emit_system(
 }
 
 fn print_plan(plan: &DevPlan) {
-    eprintln!("[dev] {} service(s)", plan.services.len());
+    eprintln!("[services] {} service(s)", plan.services.len());
     for service in &plan.services {
         let port = service
             .port
             .map(|port| format!(" :{port}"))
             .unwrap_or_default();
         eprintln!(
-            "[dev]   {}{port} -> {}",
+            "[services]   {}{port} -> {}",
             service.name, service.target_address
         );
     }
     if let Some(port) = plan.control_port {
-        eprintln!("[dev]   control :{port}");
+        eprintln!("[services]   control :{port}");
     }
 }
 
@@ -738,10 +738,10 @@ impl ControlServer {
         use std::net::TcpListener;
 
         let listener = TcpListener::bind(("127.0.0.1", port))
-            .with_context(|| format!("failed to bind dev control socket on 127.0.0.1:{port}"))?;
+            .with_context(|| format!("failed to bind services control socket on 127.0.0.1:{port}"))?;
         listener.set_nonblocking(true)?;
         let (token, token_path) = create_control_token(port)?;
-        eprintln!("[dev]   control token {}", token_path.display());
+        eprintln!("[services]   control token {}", token_path.display());
         let stop = Arc::new(AtomicBool::new(false));
         let shutdown = Arc::new(AtomicBool::new(false));
         let (tx, rx) = mpsc::channel();
@@ -890,7 +890,7 @@ fn create_control_token(port: u16) -> Result<(String, PathBuf)> {
 
     let mut random = [0u8; 32];
     getrandom::fill(&mut random)
-        .map_err(|error| anyhow::anyhow!("failed to generate dev control token: {error}"))?;
+        .map_err(|error| anyhow::anyhow!("failed to generate services control token: {error}"))?;
     let token = random
         .iter()
         .map(|byte| format!("{byte:02x}"))
@@ -900,7 +900,7 @@ fn create_control_token(port: u16) -> Result<(String, PathBuf)> {
         .map(|byte| format!("{byte:02x}"))
         .collect::<String>();
     let path = std::env::temp_dir().join(format!(
-        "aster-dev-{port}-{}-{unique}.token",
+        "aster-services-{port}-{}-{unique}.token",
         std::process::id()
     ));
     let mut options = OpenOptions::new();

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -3,7 +3,7 @@
 //! Executes target commands on projects in dependency order with parallel
 //! execution per DAG level.
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 
 pub(crate) mod command;
 pub mod logs;
@@ -21,6 +21,8 @@ pub fn quote_command_argument(value: &str) -> String {
 
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 static SUPERVISED_CHILDREN: AtomicUsize = AtomicUsize::new(0);
+static SHUTDOWN_SIGNAL: AtomicI32 = AtomicI32::new(0);
+static GRACEFUL_WHEN_IDLE: AtomicBool = AtomicBool::new(false);
 
 /// Install lightweight process signal handlers.
 ///
@@ -29,6 +31,8 @@ static SUPERVISED_CHILDREN: AtomicUsize = AtomicUsize::new(0);
 /// commands and the unsafe behavior of killing Aster's parent process group.
 pub fn install_signal_handler() -> &'static AtomicBool {
     SHUTDOWN_REQUESTED.store(false, Ordering::SeqCst);
+    SHUTDOWN_SIGNAL.store(0, Ordering::SeqCst);
+    GRACEFUL_WHEN_IDLE.store(false, Ordering::SeqCst);
 
     #[cfg(unix)]
     unsafe {
@@ -41,12 +45,33 @@ pub fn install_signal_handler() -> &'static AtomicBool {
             shutdown_handler as *const () as libc::sighandler_t,
         );
     }
+    #[cfg(windows)]
+    unsafe {
+        use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+
+        let _ = SetConsoleCtrlHandler(Some(windows_shutdown_handler), 1);
+    }
 
     &SHUTDOWN_REQUESTED
 }
 
 pub(crate) fn shutdown_requested() -> bool {
     SHUTDOWN_REQUESTED.load(Ordering::SeqCst)
+}
+
+pub fn shutdown_signal() -> Option<i32> {
+    match SHUTDOWN_SIGNAL.load(Ordering::SeqCst) {
+        0 => None,
+        signal => Some(signal),
+    }
+}
+
+pub(crate) fn request_graceful_signal_handling() {
+    GRACEFUL_WHEN_IDLE.store(true, Ordering::SeqCst);
+}
+
+pub(crate) fn request_shutdown() {
+    SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
 }
 
 pub(crate) fn register_supervised_child() {
@@ -59,10 +84,38 @@ pub(crate) fn unregister_supervised_child() {
 
 #[cfg(unix)]
 extern "C" fn shutdown_handler(signal: libc::c_int) {
-    if SUPERVISED_CHILDREN.load(Ordering::SeqCst) == 0 {
+    if SUPERVISED_CHILDREN.load(Ordering::SeqCst) == 0 && !GRACEFUL_WHEN_IDLE.load(Ordering::SeqCst)
+    {
         unsafe {
             libc::_exit(128 + signal);
         }
     }
+    SHUTDOWN_SIGNAL.store(signal, Ordering::SeqCst);
     SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
+}
+
+#[cfg(windows)]
+unsafe extern "system" fn windows_shutdown_handler(control_type: u32) -> i32 {
+    use windows_sys::Win32::System::Console::{
+        CTRL_BREAK_EVENT, CTRL_CLOSE_EVENT, CTRL_C_EVENT, CTRL_LOGOFF_EVENT, CTRL_SHUTDOWN_EVENT,
+    };
+
+    if !matches!(
+        control_type,
+        CTRL_C_EVENT
+            | CTRL_BREAK_EVENT
+            | CTRL_CLOSE_EVENT
+            | CTRL_LOGOFF_EVENT
+            | CTRL_SHUTDOWN_EVENT
+    ) {
+        return 0;
+    }
+    if SUPERVISED_CHILDREN.load(Ordering::SeqCst) == 0 && !GRACEFUL_WHEN_IDLE.load(Ordering::SeqCst)
+    {
+        return 0;
+    }
+    let signal = if control_type == CTRL_C_EVENT { 2 } else { 15 };
+    SHUTDOWN_SIGNAL.store(signal, Ordering::SeqCst);
+    SHUTDOWN_REQUESTED.store(true, Ordering::SeqCst);
+    1
 }

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -1909,12 +1909,12 @@ mod tests {
         let mut targets_a = HashMap::new();
         targets_a.insert(
             "deps".to_string(),
-            target_with_resources("sleep 0.15", vec![], vec!["resource_a"]),
+            target_with_resources("sleep 0.5", vec![], vec!["resource_a"]),
         );
         let mut targets_b = HashMap::new();
         targets_b.insert(
             "deps".to_string(),
-            target_with_resources("sleep 0.15", vec![], vec!["resource_b"]),
+            target_with_resources("sleep 0.5", vec![], vec!["resource_b"]),
         );
 
         let project_a = DiscoveredProject {
@@ -1974,10 +1974,11 @@ mod tests {
             assert!(r.success, "Target {} should succeed", r.address);
         }
 
-        // Non-contending targets should run in parallel (~150ms, not ~300ms)
+        // Non-contending targets should run in parallel (~500ms, not ~1000ms).
+        // Leave enough headroom for process startup on loaded hosted runners.
         assert!(
-            total_ms < 280,
-            "Non-contending targets should run in parallel (took {total_ms}ms, expected < 280ms)"
+            total_ms < 900,
+            "Non-contending targets should run in parallel (took {total_ms}ms, expected < 900ms)"
         );
     }
 

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -30,8 +30,9 @@ use crate::plugins::PluginRegistry;
 use crate::ui::ProgressDisplay;
 
 use super::command::parse_command;
-#[cfg(unix)]
-use super::{register_supervised_child, shutdown_requested, unregister_supervised_child};
+use super::shutdown_requested;
+#[cfg(any(unix, windows))]
+use super::{register_supervised_child, unregister_supervised_child};
 
 /// Result of executing a target command on a project
 #[derive(Debug, Clone)]
@@ -60,6 +61,8 @@ pub struct Executor<'a> {
     full_logs: bool,
     /// Whether to use caching
     use_cache: bool,
+    /// Whether child targets should receive a closed stdin.
+    null_stdin: bool,
 }
 
 impl<'a> Executor<'a> {
@@ -70,6 +73,7 @@ impl<'a> Executor<'a> {
             output_mode: OutputMode::Normal,
             full_logs: false,
             use_cache: true,
+            null_stdin: false,
         }
     }
 
@@ -80,6 +84,7 @@ impl<'a> Executor<'a> {
             output_mode,
             full_logs: false,
             use_cache: true,
+            null_stdin: false,
         }
     }
 
@@ -94,6 +99,7 @@ impl<'a> Executor<'a> {
             output_mode,
             full_logs,
             use_cache: true,
+            null_stdin: false,
         }
     }
 
@@ -109,7 +115,17 @@ impl<'a> Executor<'a> {
             output_mode,
             full_logs,
             use_cache,
+            null_stdin: false,
         }
+    }
+
+    /// Prevent targets from reading the caller's terminal.
+    ///
+    /// This is used for dev-service prerequisites, which execute in a worker
+    /// while the dashboard remains the foreground terminal process.
+    pub fn with_null_stdin(mut self) -> Self {
+        self.null_stdin = true;
+        self
     }
 
     /// Execute a target on selected projects in dependency order
@@ -192,19 +208,25 @@ impl<'a> Executor<'a> {
         }
 
         #[cfg(unix)]
-        isolate_process_group(&mut cmd);
+        isolate_streaming_session(&mut cmd);
+        #[cfg(windows)]
+        prepare_windows_child(&mut cmd);
 
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         register_supervised_child();
         let mut child = cmd.spawn().map_err(|e| {
-            #[cfg(unix)]
+            #[cfg(any(unix, windows))]
             unregister_supervised_child();
             format!("Failed to execute {target_addr}: {e}")
         })?;
         #[cfg(unix)]
         let monitor = ChildSignalMonitor::new(child.id());
+        #[cfg(windows)]
+        let monitor = WindowsChildSignalMonitor::new(&mut child)
+            .inspect_err(|_| unregister_supervised_child())
+            .map_err(|error| format!("Failed to supervise {target_addr}: {error}"))?;
         let status = child.wait();
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         monitor.finish();
         let status = status.map_err(|e| format!("Failed to execute {target_addr}: {e}"))?;
 
@@ -332,6 +354,9 @@ impl<'a> Executor<'a> {
         let mut failed_or_blocked: HashSet<String> = HashSet::new();
 
         for level in levels {
+            if shutdown_requested() {
+                break;
+            }
             let mut runnable = Vec::new();
             let mut blocked_results = Vec::new();
 
@@ -438,6 +463,9 @@ impl<'a> Executor<'a> {
         let mut handles = Vec::new();
 
         for target_addr in target_addrs {
+            if shutdown_requested() {
+                break;
+            }
             // Parse target address: //path/to/project:target_name
             let (project_addr, target_name) = match parse_target_address(target_addr) {
                 Some((p, t)) => (p, t),
@@ -574,6 +602,7 @@ impl<'a> Executor<'a> {
                 .get(&target_name)
                 .map(|t| t.invalidates_cache)
                 .unwrap_or(false);
+            let null_stdin = self.null_stdin;
             // Collect per-resource mutexes this target needs to acquire
             let target_resource_locks: Vec<Arc<Mutex<()>>> = {
                 let mut res_names: Vec<&String> = project
@@ -596,7 +625,28 @@ impl<'a> Executor<'a> {
                     .map(|m| m.lock().unwrap())
                     .collect();
 
-                let result = run_command(&addr, &command_clone, &working_dir);
+                if shutdown_requested() {
+                    let result = ExecutionResult {
+                        address: addr,
+                        success: false,
+                        skipped: true,
+                        cached: false,
+                        output: "Cancelled: shutdown requested".to_string(),
+                        duration_ms: 0,
+                    };
+                    let _ = tx_clone.send(result.clone());
+                    return result;
+                }
+                let mut result = run_command(&addr, &command_clone, &working_dir, null_stdin);
+                if shutdown_requested() {
+                    result.success = false;
+                    result.skipped = true;
+                    result.output = if result.output.is_empty() {
+                        "Cancelled: shutdown requested".to_string()
+                    } else {
+                        format!("{}\nCancelled: shutdown requested", result.output)
+                    };
+                }
 
                 if !result.success {
                     if let Some(workspace_root) = cache_store_path.as_ref() {
@@ -1048,7 +1098,12 @@ fn is_default_cacheable_target(target_name: &str) -> bool {
 }
 
 /// Run a command in a directory and capture output
-fn run_command(address: &str, command: &str, working_dir: &Path) -> ExecutionResult {
+fn run_command(
+    address: &str,
+    command: &str,
+    working_dir: &Path,
+    null_stdin: bool,
+) -> ExecutionResult {
     let start = Instant::now();
 
     let parsed = match parse_command(command) {
@@ -1081,6 +1136,9 @@ fn run_command(address: &str, command: &str, working_dir: &Path) -> ExecutionRes
         .current_dir(working_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if null_stdin {
+        cmd.stdin(Stdio::null());
+    }
 
     // Set environment variables
     for (name, value) in parsed.env {
@@ -1088,23 +1146,30 @@ fn run_command(address: &str, command: &str, working_dir: &Path) -> ExecutionRes
     }
 
     #[cfg(unix)]
-    isolate_process_group(&mut cmd);
+    isolate_streaming_session(&mut cmd);
+    #[cfg(windows)]
+    prepare_windows_child(&mut cmd);
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     register_supervised_child();
     let result = cmd
         .spawn()
         .inspect_err(|_| {
-            #[cfg(unix)]
+            #[cfg(any(unix, windows))]
             unregister_supervised_child();
         })
         .and_then(|child| {
+            #[cfg(windows)]
+            let mut child = child;
             #[cfg(unix)]
             let monitor = ChildSignalMonitor::new(child.id());
+            #[cfg(windows)]
+            let monitor = WindowsChildSignalMonitor::new(&mut child)
+                .inspect_err(|_| unregister_supervised_child())?;
 
             let output = child.wait_with_output();
 
-            #[cfg(unix)]
+            #[cfg(any(unix, windows))]
             monitor.finish();
 
             output
@@ -1149,8 +1214,161 @@ fn run_command(address: &str, command: &str, working_dir: &Path) -> ExecutionRes
     }
 }
 
+#[cfg(windows)]
+fn prepare_windows_child(command: &mut Command) {
+    use std::os::windows::process::CommandExt;
+
+    command.creation_flags(windows_sys::Win32::System::Threading::CREATE_SUSPENDED);
+}
+
+#[cfg(windows)]
+struct WindowsChildSignalMonitor {
+    completed: Arc<AtomicBool>,
+    handle: Option<thread::JoinHandle<()>>,
+    termination_handle: windows_sys::Win32::Foundation::HANDLE,
+    job_backed: bool,
+    registered: bool,
+}
+
+#[cfg(windows)]
+impl WindowsChildSignalMonitor {
+    fn new(child: &mut std::process::Child) -> std::io::Result<Self> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::System::JobObjects::{AssignProcessToJobObject, CreateJobObjectW};
+
+        unsafe {
+            let job = CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if job.is_null() {
+                let error = std::io::Error::last_os_error();
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+            let assigned = AssignProcessToJobObject(job, child.as_raw_handle() as _) != 0;
+            let assignment_error = (!assigned).then(std::io::Error::last_os_error);
+            let (termination_handle, job_backed) = if assigned {
+                (job, true)
+            } else if assignment_error
+                .as_ref()
+                .and_then(std::io::Error::raw_os_error)
+                == Some(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as i32)
+            {
+                windows_sys::Win32::Foundation::CloseHandle(job);
+                (std::ptr::null_mut(), false)
+            } else {
+                let error = assignment_error.unwrap_or_else(std::io::Error::last_os_error);
+                windows_sys::Win32::Foundation::CloseHandle(job);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            };
+            if let Err(error) = resume_windows_process(child.id()) {
+                windows_sys::Win32::Foundation::CloseHandle(termination_handle);
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error);
+            }
+
+            let completed = Arc::new(AtomicBool::new(false));
+            let completed_for_thread = completed.clone();
+            let termination_value = termination_handle as usize;
+            let root_process_id = child.id();
+            let handle = thread::spawn(move || {
+                while !completed_for_thread.load(Ordering::SeqCst) {
+                    if shutdown_requested() {
+                        let handle = termination_value as windows_sys::Win32::Foundation::HANDLE;
+                        if job_backed {
+                            windows_sys::Win32::System::JobObjects::TerminateJobObject(handle, 1);
+                        } else {
+                            crate::windows_process::terminate_process_tree(root_process_id);
+                        }
+                        return;
+                    }
+                    thread::park_timeout(Duration::from_millis(20));
+                }
+            });
+            Ok(Self {
+                completed,
+                handle: Some(handle),
+                termination_handle,
+                job_backed,
+                registered: true,
+            })
+        }
+    }
+
+    fn finish(mut self) {
+        self.cleanup();
+    }
+
+    fn cleanup(&mut self) {
+        self.completed.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            handle.thread().unpark();
+            let _ = handle.join();
+        }
+        if !self.termination_handle.is_null() {
+            unsafe {
+                windows_sys::Win32::Foundation::CloseHandle(self.termination_handle);
+            }
+            self.termination_handle = std::ptr::null_mut();
+        }
+        if self.registered {
+            unregister_supervised_child();
+            self.registered = false;
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsChildSignalMonitor {
+    fn drop(&mut self) {
+        self.cleanup();
+    }
+}
+
+#[cfg(windows)]
+fn resume_windows_process(process_id: u32) -> std::io::Result<()> {
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+    };
+    use windows_sys::Win32::System::Threading::{OpenThread, ResumeThread, THREAD_SUSPEND_RESUME};
+
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut entry: THREADENTRY32 = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<THREADENTRY32>() as u32;
+        let mut has_entry = Thread32First(snapshot, &mut entry) != 0;
+        while has_entry {
+            if entry.th32OwnerProcessID == process_id {
+                let thread = OpenThread(THREAD_SUSPEND_RESUME, 0, entry.th32ThreadID);
+                if thread.is_null() {
+                    let error = std::io::Error::last_os_error();
+                    CloseHandle(snapshot);
+                    return Err(error);
+                }
+                let result = ResumeThread(thread);
+                let error = (result == u32::MAX).then(std::io::Error::last_os_error);
+                CloseHandle(thread);
+                CloseHandle(snapshot);
+                return error.map_or(Ok(()), Err);
+            }
+            has_entry = Thread32Next(snapshot, &mut entry) != 0;
+        }
+        CloseHandle(snapshot);
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "suspended process had no discoverable primary thread",
+    ))
+}
+
 #[cfg(unix)]
-fn isolate_process_group(command: &mut Command) {
+fn isolate_streaming_session(command: &mut Command) {
     use std::os::unix::process::CommandExt;
 
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod address;
 pub mod cache;
 pub mod cli;
 pub mod config;
+pub mod dev;
 pub mod discovery;
 pub mod executor;
 pub mod git;
@@ -10,6 +11,8 @@ pub mod plugins;
 pub mod targets;
 pub mod ui;
 pub mod watch;
+#[cfg(windows)]
+mod windows_process;
 
 // Re-export core types for convenience
 pub use cli::{Cli, Commands};

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::process::ExitCode;
 use aster::cli::{
     build_execution_output, check_reserved_target, expand_selection, output_json, parse_run_args,
     print_summary, select_projects, Cli, Commands, GraphOutput, OutputMode, ProjectCommands,
-    ProjectInfo, WhyOutput,
+    ProjectInfo, ServicesCommands, WhyOutput,
 };
 use aster::config::{find_workspace_root, WorkspaceConfig};
 use aster::discovery::{discover_projects, DiscoveredProject};
@@ -946,39 +946,41 @@ fn run() -> Result<()> {
                 cli.no_cache,
             )?;
         }
-        Commands::Dev {
-            services,
-            no_watch,
-            no_ui,
-            dry_run,
-        } => {
-            let workspace_config = WorkspaceConfig::load(&workspace_root)?;
-            let graph = build_target_graph(&projects);
-            if let Some(cycle) = graph.find_cycle() {
-                return Err(anyhow::anyhow!("{cycle}"));
+        Commands::Services { command } => match command {
+            ServicesCommands::Up {
+                services,
+                no_watch,
+                no_ui,
+                dry_run,
+            } => {
+                let workspace_config = WorkspaceConfig::load(&workspace_root)?;
+                let graph = build_target_graph(&projects);
+                if let Some(cycle) = graph.find_cycle() {
+                    return Err(anyhow::anyhow!("{cycle}"));
+                }
+                let plan = aster::dev::resolve_dev_plan(
+                    &workspace_root,
+                    &workspace_config.dev,
+                    &services,
+                    &projects,
+                    &graph,
+                    &registry,
+                )?;
+                aster::dev::run_dev(
+                    &workspace_root,
+                    projects,
+                    graph,
+                    plan,
+                    &workspace_config,
+                    aster::dev::DevOptions {
+                        watch: !no_watch,
+                        ui: !no_ui,
+                        dry_run,
+                        use_cache: !cli.no_cache,
+                    },
+                )?;
             }
-            let plan = aster::dev::resolve_dev_plan(
-                &workspace_root,
-                &workspace_config.dev,
-                &services,
-                &projects,
-                &graph,
-                &registry,
-            )?;
-            aster::dev::run_dev(
-                &workspace_root,
-                projects,
-                graph,
-                plan,
-                &workspace_config,
-                aster::dev::DevOptions {
-                    watch: !no_watch,
-                    ui: !no_ui,
-                    dry_run,
-                    use_cache: !cli.no_cache,
-                },
-            )?;
-        }
+        },
         Commands::RunTarget { ref args } | Commands::ExternalTarget(ref args) => {
             // Parse external subcommand args
             let run_args = parse_run_args(args.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use aster::discovery::{discover_projects, DiscoveredProject};
 use aster::executor::logs::LogStore;
 use aster::executor::{
     collect_target_deps, compute_target_levels, install_signal_handler, parse_target_address,
-    Executor,
+    shutdown_signal, Executor,
 };
 use aster::git::{affected_with_dependents, files_to_projects, AffectedDetector, AffectedIgnore};
 use aster::graph::{build_graph, build_target_graph, find_cycle, format_path};
@@ -37,7 +37,11 @@ const CACHE_HASH_DISPLAY_LENGTH: usize = 8;
 
 fn main() -> ExitCode {
     install_signal_handler();
-    match run() {
+    let result = run();
+    if let Some(signal) = shutdown_signal() {
+        return ExitCode::from(u8::try_from(128 + signal).unwrap_or(u8::MAX));
+    }
+    match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("error: {e:#}");
@@ -83,6 +87,7 @@ fn run() -> Result<()> {
         eprintln!("[aster] Discovered {} projects", projects.len());
     }
 
+    let explicit_target = matches!(&cli.command, Commands::RunTarget { .. });
     match cli.command {
         Commands::Init => unreachable!("Init handled above"),
         Commands::List { path, lang } => {
@@ -941,7 +946,40 @@ fn run() -> Result<()> {
                 cli.no_cache,
             )?;
         }
-        Commands::Target(ref args) => {
+        Commands::Dev {
+            services,
+            no_watch,
+            no_ui,
+            dry_run,
+        } => {
+            let workspace_config = WorkspaceConfig::load(&workspace_root)?;
+            let graph = build_target_graph(&projects);
+            if let Some(cycle) = graph.find_cycle() {
+                return Err(anyhow::anyhow!("{cycle}"));
+            }
+            let plan = aster::dev::resolve_dev_plan(
+                &workspace_root,
+                &workspace_config.dev,
+                &services,
+                &projects,
+                &graph,
+                &registry,
+            )?;
+            aster::dev::run_dev(
+                &workspace_root,
+                projects,
+                graph,
+                plan,
+                &workspace_config,
+                aster::dev::DevOptions {
+                    watch: !no_watch,
+                    ui: !no_ui,
+                    dry_run,
+                    use_cache: !cli.no_cache,
+                },
+            )?;
+        }
+        Commands::RunTarget { ref args } | Commands::ExternalTarget(ref args) => {
             // Parse external subcommand args
             let run_args = parse_run_args(args.clone());
 
@@ -971,8 +1009,10 @@ fn run() -> Result<()> {
             let full_logs = cli.full_logs();
 
             // Check for reserved command conflicts
-            if let Some(err_msg) = check_reserved_target(&run_args.target) {
-                return Err(anyhow::anyhow!("{err_msg}"));
+            if !explicit_target {
+                if let Some(err_msg) = check_reserved_target(&run_args.target) {
+                    return Err(anyhow::anyhow!("{err_msg}"));
+                }
             }
 
             // Build the graph

--- a/src/watch/event_loop.rs
+++ b/src/watch/event_loop.rs
@@ -957,11 +957,11 @@ mod tests {
         };
         let (tx, shutdown, dispatches, handle) = spawn_loop_with_fixture(f, opts, None);
 
-        // Three events within the debounce window.
+        // Queue three events together. Sleeping between sends makes this test
+        // depend on scheduler latency and can push the last event outside the
+        // debounce window on loaded hosted runners.
         send_modify(&tx, "/repo/libs/core/src/a.ts");
-        std::thread::sleep(Duration::from_millis(30));
         send_modify(&tx, "/repo/libs/core/src/b.ts");
-        std::thread::sleep(Duration::from_millis(30));
         send_modify(&tx, "/repo/services/api/src/main.ts");
 
         // Wait for dispatch to fire after debounce elapses.

--- a/src/watch/stream.rs
+++ b/src/watch/stream.rs
@@ -10,7 +10,7 @@ use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
 use crate::executor::command::parse_command;
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use crate::executor::{register_supervised_child, unregister_supervised_child};
 use crate::plugins::Target;
 
@@ -19,13 +19,13 @@ pub struct StreamChild {
     child: Child,
     #[cfg(unix)]
     pgid: Option<i32>,
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     registered: bool,
 }
 
 impl Drop for StreamChild {
     fn drop(&mut self) {
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         if self.registered {
             unregister_supervised_child();
             self.registered = false;
@@ -74,6 +74,8 @@ impl StreamChild {
         #[cfg(not(unix))]
         {
             let _ = grace;
+            #[cfg(windows)]
+            crate::windows_process::terminate_process_tree(self.child.id());
             let _ = self.child.kill();
         }
 
@@ -186,12 +188,12 @@ fn spawn_child(target: &Target, project_root: &Path) -> Result<StreamChild> {
         }
     }
 
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     register_supervised_child();
     let child = cmd
         .spawn()
         .inspect_err(|_| {
-            #[cfg(unix)]
+            #[cfg(any(unix, windows))]
             unregister_supervised_child();
         })
         .context("spawn failed")?;
@@ -207,6 +209,8 @@ fn spawn_child(target: &Target, project_root: &Path) -> Result<StreamChild> {
         #[cfg(unix)]
         pgid,
         #[cfg(unix)]
+        registered: true,
+        #[cfg(windows)]
         registered: true,
     })
 }

--- a/src/windows_process.rs
+++ b/src/windows_process.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+use std::time::Duration;
+
+use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W, TH32CS_SNAPPROCESS,
+};
+use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+
+/// Best-effort process-tree termination for environments where nested Job
+/// Objects are unavailable. The known set is retained across passes so children
+/// whose parents exit during traversal remain attributable to the original root.
+pub(crate) fn terminate_process_tree(root: u32) {
+    let mut known = HashSet::from([root]);
+    for _ in 0..4 {
+        let entries = process_entries();
+        loop {
+            let before = known.len();
+            for (pid, parent) in &entries {
+                if known.contains(parent) {
+                    known.insert(*pid);
+                }
+            }
+            if known.len() == before {
+                break;
+            }
+        }
+        terminate_process(root);
+        for pid in known.iter().copied().filter(|pid| *pid != root) {
+            terminate_process(pid);
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn process_entries() -> Vec<(u32, u32)> {
+    unsafe {
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot == INVALID_HANDLE_VALUE {
+            return Vec::new();
+        }
+        let mut entry: PROCESSENTRY32W = std::mem::zeroed();
+        entry.dwSize = std::mem::size_of::<PROCESSENTRY32W>() as u32;
+        let mut entries = Vec::new();
+        let mut has_entry = Process32FirstW(snapshot, &mut entry) != 0;
+        while has_entry {
+            entries.push((entry.th32ProcessID, entry.th32ParentProcessID));
+            has_entry = Process32NextW(snapshot, &mut entry) != 0;
+        }
+        CloseHandle(snapshot);
+        entries
+    }
+}
+
+fn terminate_process(pid: u32) {
+    unsafe {
+        let process = OpenProcess(PROCESS_TERMINATE, 0, pid);
+        if !process.is_null() {
+            TerminateProcess(process, 1);
+            CloseHandle(process);
+        }
+    }
+}

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -26,6 +26,18 @@ fn occurrences(path: &Path, needle: &str) -> usize {
         .count()
 }
 
+fn process_is_running(pid: i32) -> bool {
+    if unsafe { libc::kill(pid, 0) } == -1 {
+        return false;
+    }
+    let output = Command::new("ps")
+        .args(["-o", "stat=", "-p", &pid.to_string()])
+        .output()
+        .unwrap();
+    let state = String::from_utf8_lossy(&output.stdout);
+    !state.trim().is_empty() && !state.trim_start().starts_with('Z')
+}
+
 fn control_request(port: u16, request: &str) -> serde_json::Value {
     let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
     writeln!(stream, "{request}").unwrap();
@@ -206,9 +218,10 @@ command = "sh -c 'echo BUILD >> ../events.log'"
     }
     let status = aster.wait().unwrap();
     assert_eq!(status.code(), Some(143));
-    wait_until(Duration::from_secs(5), || unsafe {
-        libc::kill(child_pid, 0) == -1
-    });
+    // A killed grandchild can remain as a zombie briefly on hosted macOS
+    // runners. It is no longer executing, so treat that as terminated while
+    // still rejecting any live descendant.
+    wait_until(Duration::from_secs(5), || !process_is_running(child_pid));
     assert!(TcpStream::connect(("127.0.0.1", port)).is_err());
 }
 

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -70,16 +70,12 @@ fn wait_for_control_token(port: u16, process_id: u32) -> (std::path::PathBuf, St
 fn dev_supervises_targets_runs_prerequisites_and_restarts_on_dependency_changes() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();
-    let port = TcpListener::bind(("127.0.0.1", 0))
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port();
-    let control_port = TcpListener::bind(("127.0.0.1", 0))
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port();
+    // Keep both reservations open until launch so the OS cannot assign the
+    // same ephemeral port to HTTP and the control server.
+    let port_reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = port_reservation.local_addr().unwrap().port();
+    let control_port_reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let control_port = control_port_reservation.local_addr().unwrap().port();
     fs::create_dir(root.join(".git")).unwrap();
     fs::create_dir_all(root.join("app")).unwrap();
     fs::create_dir_all(root.join("lib/src")).unwrap();
@@ -139,6 +135,8 @@ command = "sh -c 'echo BUILD >> ../events.log'"
 
     // Process boundary: launch the public CLI, which starts a real prerequisite
     // process and a real HTTP child in its own process group.
+    drop(port_reservation);
+    drop(control_port_reservation);
     let mut aster = Command::new(env!("CARGO_BIN_EXE_aster"))
         .args(["services", "up", "--no-ui"])
         .current_dir(root)
@@ -149,7 +147,7 @@ command = "sh -c 'echo BUILD >> ../events.log'"
         .spawn()
         .unwrap();
     let events = root.join("events.log");
-    wait_until(Duration::from_secs(12), || {
+    wait_until(Duration::from_secs(30), || {
         occurrences(&events, "PREPARE") >= 1
             && occurrences(&events, &format!("START:{port}")) >= 1
             && TcpStream::connect(("127.0.0.1", port)).is_ok()

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -1,7 +1,7 @@
 #![cfg(unix)]
 
 use std::fs;
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -43,6 +43,29 @@ fn process_is_running(pid: i32) -> bool {
         .unwrap();
     let state = String::from_utf8_lossy(&output.stdout);
     !state.trim().is_empty() && !state.trim_start().starts_with('Z')
+}
+
+fn fail_with_process_diagnostics(
+    aster: &mut std::process::Child,
+    events: &Path,
+    context: &str,
+) -> ! {
+    unsafe {
+        libc::kill(aster.id() as i32, libc::SIGTERM);
+    }
+    let status = aster.wait().unwrap();
+    let mut stdout = String::new();
+    if let Some(mut pipe) = aster.stdout.take() {
+        pipe.read_to_string(&mut stdout).unwrap();
+    }
+    let mut stderr = String::new();
+    if let Some(mut pipe) = aster.stderr.take() {
+        pipe.read_to_string(&mut stderr).unwrap();
+    }
+    panic!(
+        "{context}:\nstatus: {status}\nevents:\n{}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        fs::read_to_string(events).unwrap_or_default(),
+    );
 }
 
 fn control_request(port: u16, request: &str) -> serde_json::Value {
@@ -160,16 +183,7 @@ command = "sh -c 'echo BUILD >> ../events.log'"
             && TcpStream::connect(("127.0.0.1", port)).is_ok()
     });
     if !started {
-        unsafe {
-            libc::kill(aster.id() as i32, libc::SIGTERM);
-        }
-        let output = aster.wait_with_output().unwrap();
-        panic!(
-            "service did not start:\n{}\nstdout:\n{}\nstderr:\n{}",
-            fs::read_to_string(&events).unwrap_or_default(),
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
-        );
+        fail_with_process_diagnostics(&mut aster, &events, "service did not start");
     }
     assert_eq!(occurrences(&events, "AMBIENT_SECRET_LEAKED"), 0);
     assert!(fs::read_to_string(&events)
@@ -186,18 +200,28 @@ command = "sh -c 'echo BUILD >> ../events.log'"
     // window expires, even when its path matches suppress_paths.
     thread::sleep(Duration::from_secs(1));
     fs::write(root.join("lib/src/suppressed.js"), "manual").unwrap();
-    wait_until(Duration::from_secs(10), || {
+    let suppressed_restart_completed = condition_met(Duration::from_secs(20), || {
         occurrences(&events, "PREPARE") >= 2 && TcpStream::connect(("127.0.0.1", port)).is_ok()
     });
+    if !suppressed_restart_completed {
+        fail_with_process_diagnostics(
+            &mut aster,
+            &events,
+            "suppressed-path restart did not complete",
+        );
+    }
     thread::sleep(Duration::from_secs(2));
 
     // Watch boundary: mutate the transitive library dependency, not the service
     // directory. Mutate it again while the deliberately slow prerequisite is
     // running; that genuine source event must survive the restart cooldown.
     fs::write(root.join("lib/src/input.js"), "second").unwrap();
-    wait_until(Duration::from_secs(10), || {
+    let dependency_restart_started = condition_met(Duration::from_secs(20), || {
         occurrences(&events, "PREPARE") >= 3
     });
+    if !dependency_restart_started {
+        fail_with_process_diagnostics(&mut aster, &events, "dependency restart did not start");
+    }
     thread::sleep(Duration::from_millis(250));
     fs::write(root.join("lib/src/input.js"), "third").unwrap();
     let deadline = Instant::now() + Duration::from_secs(30);

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -218,7 +218,7 @@ command = "sh -c 'echo BUILD >> ../events.log'"
     thread::sleep(Duration::from_secs(1));
     fs::write(root.join("lib/src/suppressed.js"), "manual").unwrap();
     let suppressed_restart_completed = condition_met(Duration::from_secs(20), || {
-        occurrences(&events, "PREPARE") >= 2 && TcpStream::connect(("127.0.0.1", port)).is_ok()
+        occurrences(&events, "PREPARE") >= 2
     });
     if !suppressed_restart_completed {
         fail_with_process_diagnostics(

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -35,7 +35,7 @@ fn control_request(port: u16, request: &str) -> serde_json::Value {
 }
 
 fn wait_for_control_token(port: u16, process_id: u32) -> (std::path::PathBuf, String) {
-    let prefix = format!("aster-dev-{port}-{process_id}-");
+    let prefix = format!("aster-services-{port}-{process_id}-");
     let mut found = None;
     wait_until(Duration::from_secs(5), || {
         found = fs::read_dir(std::env::temp_dir())
@@ -128,7 +128,7 @@ command = "sh -c 'echo BUILD >> ../events.log'"
     // Process boundary: launch the public CLI, which starts a real prerequisite
     // process and a real HTTP child in its own process group.
     let mut aster = Command::new(env!("CARGO_BIN_EXE_aster"))
-        .args(["dev", "--no-ui"])
+        .args(["services", "up", "--no-ui"])
         .current_dir(root)
         .env("ASTER_AMBIENT_SECRET", "must-not-reach-service")
         .env("ASTER_ALLOWED_VALUE", "explicitly-allowed")
@@ -264,7 +264,7 @@ stream = true
     // No supervised child is ever registered. SIGTERM must still take the
     // graceful dev-loop path so an interactive caller can restore its terminal.
     let aster = Command::new(env!("CARGO_BIN_EXE_aster"))
-        .args(["dev", "--no-ui"])
+        .args(["services", "up", "--no-ui"])
         .current_dir(root)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
@@ -319,7 +319,7 @@ stream = true
     .unwrap();
 
     let mut aster = Command::new(env!("CARGO_BIN_EXE_aster"))
-        .args(["dev", "--no-ui"])
+        .args(["services", "up", "--no-ui"])
         .current_dir(root)
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -387,7 +387,7 @@ stream = true
     .unwrap();
 
     let mut aster = Command::new(env!("CARGO_BIN_EXE_aster"))
-        .args(["dev", "--no-ui"])
+        .args(["services", "up", "--no-ui"])
         .current_dir(root)
         .stdout(Stdio::null())
         .stderr(Stdio::null())

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -1,0 +1,409 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if condition() {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    panic!("condition was not satisfied within {timeout:?}");
+}
+
+fn occurrences(path: &Path, needle: &str) -> usize {
+    fs::read_to_string(path)
+        .unwrap_or_default()
+        .matches(needle)
+        .count()
+}
+
+fn control_request(port: u16, request: &str) -> serde_json::Value {
+    let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+    writeln!(stream, "{request}").unwrap();
+    let mut response = String::new();
+    BufReader::new(stream).read_line(&mut response).unwrap();
+    serde_json::from_str(&response).unwrap()
+}
+
+fn wait_for_control_token(port: u16, process_id: u32) -> (std::path::PathBuf, String) {
+    let prefix = format!("aster-dev-{port}-{process_id}-");
+    let mut found = None;
+    wait_until(Duration::from_secs(5), || {
+        found = fs::read_dir(std::env::temp_dir())
+            .unwrap()
+            .filter_map(Result::ok)
+            .map(|entry| entry.path())
+            .find(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with(&prefix) && name.ends_with(".token"))
+            });
+        found.is_some()
+    });
+    let path = found.unwrap();
+    let token = fs::read_to_string(&path).unwrap();
+    (path, token)
+}
+
+#[test]
+fn dev_supervises_targets_runs_prerequisites_and_restarts_on_dependency_changes() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let port = TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    let control_port = TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::create_dir_all(root.join("app")).unwrap();
+    fs::create_dir_all(root.join("lib/src")).unwrap();
+    fs::create_dir_all(root.join("lib/generated")).unwrap();
+    fs::write(root.join("app/package.json"), r#"{"name":"app"}"#).unwrap();
+    fs::write(root.join("lib/package.json"), r#"{"name":"lib"}"#).unwrap();
+    fs::write(root.join("lib/src/input.js"), "first").unwrap();
+
+    // Configuration boundary: a service maps to one stream target, and ordinary
+    // target dependencies describe both preparation and the watched library.
+    fs::write(
+        root.join("aster.toml"),
+        format!(
+            r#"
+[dev]
+control_port = "control"
+
+[watch]
+suppress_paths = ["lib/src/suppressed.js"]
+
+[dev.ports.http]
+default = {port}
+
+[dev.ports.control]
+default = {control_port}
+
+[dev.services.web]
+target = "//app:dev"
+port = "http"
+inherit_env = ["ASTER_ALLOWED_VALUE"]
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/aster.toml"),
+        r#"
+[targets.prepare]
+command = "sh -c 'count=$(grep -c PREPARE ../events.log 2>/dev/null || true); echo PREPARE >> ../events.log; if [ \"$count\" -ge 1 ]; then sleep 1; echo generated > ../lib/src/suppressed.js; fi'"
+depends_on = ["//lib:build"]
+
+[targets.dev]
+command = "sh -c 'if [ -n \"${ASTER_AMBIENT_SECRET:-}\" ]; then echo AMBIENT_SECRET_LEAKED >> ../events.log; fi; echo INHERITED:$ASTER_ALLOWED_VALUE >> ../events.log; echo START:$ASTER_SERVICE_PORT >> ../events.log; python3 -m http.server {port} & server=$!; echo $server > ../child.pid; wait $server'"
+depends_on = ["//self:prepare"]
+stream = true
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("lib/aster.toml"),
+        r#"
+[targets.build]
+command = "sh -c 'echo BUILD >> ../events.log'"
+"#,
+    )
+    .unwrap();
+
+    // Process boundary: launch the public CLI, which starts a real prerequisite
+    // process and a real HTTP child in its own process group.
+    let mut aster = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["dev", "--no-ui"])
+        .current_dir(root)
+        .env("ASTER_AMBIENT_SECRET", "must-not-reach-service")
+        .env("ASTER_ALLOWED_VALUE", "explicitly-allowed")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let events = root.join("events.log");
+    wait_until(Duration::from_secs(12), || {
+        occurrences(&events, "PREPARE") >= 1
+            && occurrences(&events, &format!("START:{port}")) >= 1
+            && TcpStream::connect(("127.0.0.1", port)).is_ok()
+    });
+    assert_eq!(occurrences(&events, "AMBIENT_SECRET_LEAKED"), 0);
+    assert!(fs::read_to_string(&events)
+        .unwrap()
+        .contains("INHERITED:explicitly-allowed"));
+    let status = control_request(control_port, r#"{"command":"status"}"#);
+    assert_eq!(status["ok"], true);
+    assert_eq!(status["services"]["web"], "running");
+    let unauthorized = control_request(control_port, r#"{"command":"restart_all"}"#);
+    assert_eq!(unauthorized["ok"], false);
+    assert_eq!(unauthorized["error"], "valid control token required");
+
+    // The first event after startup is still eligible once the suppression
+    // window expires, even when its path matches suppress_paths.
+    thread::sleep(Duration::from_secs(1));
+    fs::write(root.join("lib/src/suppressed.js"), "manual").unwrap();
+    wait_until(Duration::from_secs(10), || {
+        occurrences(&events, "PREPARE") >= 2 && TcpStream::connect(("127.0.0.1", port)).is_ok()
+    });
+    thread::sleep(Duration::from_secs(2));
+
+    // Watch boundary: mutate the transitive library dependency, not the service
+    // directory. Mutate it again while the deliberately slow prerequisite is
+    // running; that genuine source event must survive the restart cooldown.
+    fs::write(root.join("lib/src/input.js"), "second").unwrap();
+    wait_until(Duration::from_secs(10), || {
+        occurrences(&events, "PREPARE") >= 3
+    });
+    thread::sleep(Duration::from_millis(250));
+    fs::write(root.join("lib/src/input.js"), "third").unwrap();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline
+        && (occurrences(&events, "PREPARE") < 4 || TcpStream::connect(("127.0.0.1", port)).is_err())
+    {
+        thread::sleep(Duration::from_millis(100));
+    }
+    if occurrences(&events, "PREPARE") < 4 || TcpStream::connect(("127.0.0.1", port)).is_err() {
+        unsafe {
+            libc::kill(aster.id() as i32, libc::SIGTERM);
+        }
+        let output = aster.wait_with_output().unwrap();
+        panic!(
+            "restart did not settle:\n{}\nstdout:\n{}\nstderr:\n{}",
+            fs::read_to_string(&events).unwrap_or_default(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    thread::sleep(Duration::from_secs(2));
+    assert_eq!(occurrences(&events, "PREPARE"), 4);
+
+    // Shutdown boundary: SIGTERM the launcher and observe conventional status
+    // plus complete process-group cleanup of the HTTP descendant.
+    let child_pid: i32 = fs::read_to_string(root.join("child.pid"))
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+    let _partial_control_request = TcpStream::connect(("127.0.0.1", control_port)).unwrap();
+    thread::sleep(Duration::from_millis(100));
+    unsafe {
+        libc::kill(aster.id() as i32, libc::SIGTERM);
+    }
+    let status = aster.wait().unwrap();
+    assert_eq!(status.code(), Some(143));
+    wait_until(Duration::from_secs(5), || unsafe {
+        libc::kill(child_pid, 0) == -1
+    });
+    assert!(TcpStream::connect(("127.0.0.1", port)).is_err());
+}
+
+#[test]
+fn dev_restores_through_normal_shutdown_when_every_service_fails_to_start() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let control_port = TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::create_dir(root.join("app")).unwrap();
+    fs::write(root.join("app/package.json"), r#"{"name":"app"}"#).unwrap();
+    fs::write(
+        root.join("aster.toml"),
+        format!(
+            r#"
+[dev]
+control_port = "control"
+
+[dev.ports.control]
+default = {control_port}
+
+[dev.services.broken]
+target = "//app:dev"
+
+[dev.services.crashy]
+target = "//app:crash"
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/aster.toml"),
+        r#"
+[targets.dev]
+command = "this-command-does-not-exist"
+depends_on = ["//self:prepare"]
+stream = true
+
+[targets.prepare]
+command = "sh -c 'echo PRESTEP_DIAGNOSTIC >&2; exit 7'"
+
+[targets.crash]
+command = "sh -c 'touch ../crash-ran; printf PART; printf IAL; printf \"\\377\"; echo FINAL >&2; exit 7'"
+stream = true
+"#,
+    )
+    .unwrap();
+
+    // No supervised child is ever registered. SIGTERM must still take the
+    // graceful dev-loop path so an interactive caller can restore its terminal.
+    let aster = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["dev", "--no-ui"])
+        .current_dir(root)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_until(Duration::from_secs(5), || {
+        TcpStream::connect(("127.0.0.1", control_port)).is_ok() && root.join("crash-ran").exists()
+    });
+    let status = control_request(control_port, r#"{"command":"status"}"#);
+    assert_eq!(status["services"]["broken"], "stopped");
+    assert_eq!(status["services"]["crashy"], "stopped");
+    unsafe {
+        libc::kill(aster.id() as i32, libc::SIGTERM);
+    }
+    let output = aster.wait_with_output().unwrap();
+    assert_eq!(output.status.code(), Some(143));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("PRESTEP_DIAGNOSTIC"));
+    assert!(stdout.contains("prerequisite failed"));
+    assert!(stdout.contains("PARTIAL"));
+    assert!(stdout.contains("FINAL"));
+}
+
+#[test]
+fn dev_does_not_start_a_service_after_shutdown_interrupts_its_prerequisite() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::create_dir(root.join("app")).unwrap();
+    fs::write(root.join("app/package.json"), r#"{"name":"app"}"#).unwrap();
+    fs::write(
+        root.join("aster.toml"),
+        r#"
+[dev.services.web]
+target = "//app:dev"
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/aster.toml"),
+        r#"
+[targets.prepare]
+command = "sh -c 'trap \"exit 0\" TERM; echo PREPARE_STARTED >> ../events.log; sleep 30'"
+cache = { enabled = true, include = ["package.json"] }
+
+[targets.dev]
+command = "sh -c 'echo SERVICE_STARTED >> ../events.log; sleep 30'"
+depends_on = ["//self:prepare"]
+stream = true
+"#,
+    )
+    .unwrap();
+
+    let mut aster = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["dev", "--no-ui"])
+        .current_dir(root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let events = root.join("events.log");
+    wait_until(Duration::from_secs(5), || {
+        occurrences(&events, "PREPARE_STARTED") == 1
+    });
+    unsafe {
+        libc::kill(aster.id() as i32, libc::SIGTERM);
+    }
+    let status = aster.wait().unwrap();
+    assert_eq!(status.code(), Some(143));
+    assert_eq!(occurrences(&events, "SERVICE_STARTED"), 0);
+    assert!(!fs::read_to_string(root.join(".aster/cache.json"))
+        .unwrap_or_default()
+        .contains("//app:prepare"));
+}
+
+#[test]
+fn authenticated_control_shutdown_interrupts_an_in_progress_prerequisite() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let control_port = TcpListener::bind(("127.0.0.1", 0))
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::create_dir(root.join("app")).unwrap();
+    fs::write(root.join("app/package.json"), r#"{"name":"app"}"#).unwrap();
+    fs::write(
+        root.join("aster.toml"),
+        format!(
+            r#"
+[dev]
+control_port = "control"
+
+[dev.ports.control]
+default = {control_port}
+
+[dev.services.web]
+target = "//app:dev"
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/aster.toml"),
+        r#"
+[targets.prepare]
+command = "sh -c 'trap \"exit 0\" TERM; echo PREPARE_STARTED >> ../events.log; sleep 30'"
+
+[targets.later]
+command = "sh -c 'echo LATER_SIDE_EFFECT >> ../events.log'"
+depends_on = ["//self:prepare"]
+
+[targets.dev]
+command = "sh -c 'echo SERVICE_STARTED >> ../events.log; sleep 30'"
+depends_on = ["//self:later"]
+stream = true
+"#,
+    )
+    .unwrap();
+
+    let mut aster = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["dev", "--no-ui"])
+        .current_dir(root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let events = root.join("events.log");
+    wait_until(Duration::from_secs(5), || {
+        occurrences(&events, "PREPARE_STARTED") == 1
+    });
+    let (token_path, token) = wait_for_control_token(control_port, aster.id());
+    let request = serde_json::json!({"command": "shutdown", "token": token}).to_string();
+    let response = control_request(control_port, &request);
+    assert_eq!(response["ok"], true);
+    let status = aster.wait().unwrap();
+    assert_eq!(status.code(), Some(0));
+    assert_eq!(occurrences(&events, "SERVICE_STARTED"), 0);
+    assert_eq!(occurrences(&events, "LATER_SIDE_EFFECT"), 0);
+    assert!(!token_path.exists());
+}

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -1,7 +1,7 @@
 #![cfg(unix)]
 
 use std::fs;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -48,23 +48,32 @@ fn process_is_running(pid: i32) -> bool {
 fn fail_with_process_diagnostics(
     aster: &mut std::process::Child,
     events: &Path,
+    stdout: &Path,
+    stderr: &Path,
     context: &str,
 ) -> ! {
     unsafe {
         libc::kill(aster.id() as i32, libc::SIGTERM);
     }
-    let status = aster.wait().unwrap();
-    let mut stdout = String::new();
-    if let Some(mut pipe) = aster.stdout.take() {
-        pipe.read_to_string(&mut stdout).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(8);
+    let mut status = None;
+    while Instant::now() < deadline {
+        status = aster.try_wait().unwrap();
+        if status.is_some() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
     }
-    let mut stderr = String::new();
-    if let Some(mut pipe) = aster.stderr.take() {
-        pipe.read_to_string(&mut stderr).unwrap();
+    if status.is_none() {
+        aster.kill().unwrap();
+        status = Some(aster.wait().unwrap());
     }
     panic!(
-        "{context}:\nstatus: {status}\nevents:\n{}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        "{context}:\nstatus: {:?}\nevents:\n{}\nstdout:\n{}\nstderr:\n{}",
+        status.unwrap(),
         fs::read_to_string(events).unwrap_or_default(),
+        fs::read_to_string(stdout).unwrap_or_default(),
+        fs::read_to_string(stderr).unwrap_or_default(),
     );
 }
 
@@ -162,6 +171,8 @@ command = "sh -c 'echo BUILD >> ../events.log'"
 "#,
     )
     .unwrap();
+    let stdout_log = tempfile::NamedTempFile::new().unwrap();
+    let stderr_log = tempfile::NamedTempFile::new().unwrap();
 
     // Process boundary: launch the public CLI, which starts a real prerequisite
     // process and a real HTTP child in its own process group.
@@ -172,8 +183,8 @@ command = "sh -c 'echo BUILD >> ../events.log'"
         .current_dir(root)
         .env("ASTER_AMBIENT_SECRET", "must-not-reach-service")
         .env("ASTER_ALLOWED_VALUE", "explicitly-allowed")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
+        .stdout(stdout_log.reopen().unwrap())
+        .stderr(stderr_log.reopen().unwrap())
         .spawn()
         .unwrap();
     let events = root.join("events.log");
@@ -183,7 +194,13 @@ command = "sh -c 'echo BUILD >> ../events.log'"
             && TcpStream::connect(("127.0.0.1", port)).is_ok()
     });
     if !started {
-        fail_with_process_diagnostics(&mut aster, &events, "service did not start");
+        fail_with_process_diagnostics(
+            &mut aster,
+            &events,
+            stdout_log.path(),
+            stderr_log.path(),
+            "service did not start",
+        );
     }
     assert_eq!(occurrences(&events, "AMBIENT_SECRET_LEAKED"), 0);
     assert!(fs::read_to_string(&events)
@@ -207,6 +224,8 @@ command = "sh -c 'echo BUILD >> ../events.log'"
         fail_with_process_diagnostics(
             &mut aster,
             &events,
+            stdout_log.path(),
+            stderr_log.path(),
             "suppressed-path restart did not complete",
         );
     }
@@ -220,7 +239,13 @@ command = "sh -c 'echo BUILD >> ../events.log'"
         occurrences(&events, "PREPARE") >= 3
     });
     if !dependency_restart_started {
-        fail_with_process_diagnostics(&mut aster, &events, "dependency restart did not start");
+        fail_with_process_diagnostics(
+            &mut aster,
+            &events,
+            stdout_log.path(),
+            stderr_log.path(),
+            "dependency restart did not start",
+        );
     }
     thread::sleep(Duration::from_millis(250));
     fs::write(root.join("lib/src/input.js"), "third").unwrap();
@@ -231,15 +256,12 @@ command = "sh -c 'echo BUILD >> ../events.log'"
         thread::sleep(Duration::from_millis(100));
     }
     if occurrences(&events, "PREPARE") < 4 || TcpStream::connect(("127.0.0.1", port)).is_err() {
-        unsafe {
-            libc::kill(aster.id() as i32, libc::SIGTERM);
-        }
-        let output = aster.wait_with_output().unwrap();
-        panic!(
-            "restart did not settle:\n{}\nstdout:\n{}\nstderr:\n{}",
-            fs::read_to_string(&events).unwrap_or_default(),
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
+        fail_with_process_diagnostics(
+            &mut aster,
+            &events,
+            stdout_log.path(),
+            stderr_log.path(),
+            "restart did not settle",
         );
     }
     thread::sleep(Duration::from_secs(2));

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -8,15 +8,22 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-fn wait_until(timeout: Duration, mut condition: impl FnMut() -> bool) {
+fn condition_met(timeout: Duration, mut condition: impl FnMut() -> bool) -> bool {
     let deadline = Instant::now() + timeout;
     while Instant::now() < deadline {
         if condition() {
-            return;
+            return true;
         }
         thread::sleep(Duration::from_millis(100));
     }
-    panic!("condition was not satisfied within {timeout:?}");
+    condition()
+}
+
+fn wait_until(timeout: Duration, condition: impl FnMut() -> bool) {
+    assert!(
+        condition_met(timeout, condition),
+        "condition was not satisfied within {timeout:?}"
+    );
 }
 
 fn occurrences(path: &Path, needle: &str) -> usize {
@@ -147,11 +154,23 @@ command = "sh -c 'echo BUILD >> ../events.log'"
         .spawn()
         .unwrap();
     let events = root.join("events.log");
-    wait_until(Duration::from_secs(30), || {
+    let started = condition_met(Duration::from_secs(30), || {
         occurrences(&events, "PREPARE") >= 1
             && occurrences(&events, &format!("START:{port}")) >= 1
             && TcpStream::connect(("127.0.0.1", port)).is_ok()
     });
+    if !started {
+        unsafe {
+            libc::kill(aster.id() as i32, libc::SIGTERM);
+        }
+        let output = aster.wait_with_output().unwrap();
+        panic!(
+            "service did not start:\n{}\nstdout:\n{}\nstderr:\n{}",
+            fs::read_to_string(&events).unwrap_or_default(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
     assert_eq!(occurrences(&events, "AMBIENT_SECRET_LEAKED"), 0);
     assert!(fs::read_to_string(&events)
         .unwrap()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -45,7 +45,7 @@ fn write_pyproject_toml(tmp: &TempDir, path: &str, content: &str) {
 }
 
 #[test]
-fn explicit_target_command_runs_a_target_named_dev() {
+fn dev_target_does_not_conflict_with_services_command() {
     let tmp = TempDir::new().unwrap();
     setup_workspace(&tmp);
     write_package_json(&tmp, "app/package.json", r#"{"name":"app"}"#);
@@ -61,7 +61,7 @@ cache = { enabled = false }
 
     let status = Command::new(env!("CARGO_BIN_EXE_aster"))
         .current_dir(tmp.path())
-        .args(["target", "dev", "//app", "--no-deps"])
+        .args(["dev", "//app", "--no-deps"])
         .status()
         .unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,6 +44,34 @@ fn write_pyproject_toml(tmp: &TempDir, path: &str, content: &str) {
     fs::write(full_path, content).unwrap();
 }
 
+#[test]
+fn explicit_target_command_runs_a_target_named_dev() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_package_json(&tmp, "app/package.json", r#"{"name":"app"}"#);
+    write_aster_toml(
+        &tmp,
+        "app/aster.toml",
+        r#"
+[targets.dev]
+command = "sh -c 'echo ran > dev-target-ran'"
+cache = { enabled = false }
+"#,
+    );
+
+    let status = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["target", "dev", "//app", "--no-deps"])
+        .status()
+        .unwrap();
+
+    assert!(status.success());
+    assert_eq!(
+        fs::read_to_string(tmp.path().join("app/dev-target-ran")).unwrap(),
+        "ran\n"
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn terminating_aster_cleans_up_the_target_process_group() {
@@ -86,7 +114,8 @@ cache = { enabled = false }
     unsafe {
         libc::kill(aster.id() as i32, libc::SIGTERM);
     }
-    let _ = aster.wait().unwrap();
+    let status = aster.wait().unwrap();
+    assert_eq!(status.code(), Some(143));
 
     let child_exists = unsafe { libc::kill(child_pid, 0) == 0 };
     assert!(!child_exists, "target process survived Aster termination");


### PR DESCRIPTION
## Summary

- add `aster services up` for config-driven long-running services
- model service pre-steps through ordinary target dependencies and restart services when watched dependencies change
- add named port resolution, environment isolation/allowlists, authenticated control socket, and cross-platform process-tree supervision
- port the latest tabbed `platform-rs` dashboard: scalable colored service tabs, focused log viewport, search, fullscreen, mouse selection, divider resizing, restart/open/copy controls, wrapping, and independent scrolling
- keep `dev` available as an ordinary target name (`aster dev ...`)

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-features` (512 tests)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo doc --locked --no-deps --all-features`
- deterministic Ratatui backend tests for tabs, large service stacks, search, Unicode wrapping, mouse switching, and divider dragging
- Astroshot PTY rendering capture and visual inspection of the tabbed dashboard
- real FirstLanding PTY startup through `aster services up`, tab/UI interaction, manual restart, control restart/authentication, dependency-watch restart, graceful quit, and SIGTERM teardown
- verified exit 143, token-file removal, listener closure, and descendant-process cleanup