### PR TITLE
fix: allow audit checks to report warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  checks: write
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary

- grant `checks: write` to the CI and release workflows
- allow `rustsec/audit-check` to report informational warnings without failing on GitHub API permissions
- unblock the v0.7.0 tag workflow

## Evidence

The previous main CI audit found no vulnerabilities, then failed with `Resource not accessible by integration` while creating its warning check. The release workflow had the same read-only permission.

## Validation

- both workflow YAML files parse successfully
- `git diff --check`