### PR TITLE
fix: satisfy release MSRV clippy

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1858,7 +1858,7 @@ fn test_dry_run_shows_full_target_graph_with_rationale() {
         .output()
         .unwrap();
 
-    assert!(output.status.success(), "Dry run failed: {:?}", output);
+    assert!(output.status.success(), "Dry run failed: {output:?}");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     // Should show the affected target with rationale
@@ -1928,7 +1928,7 @@ fn test_dry_run_shows_dependents_rationale() {
         .output()
         .unwrap();
 
-    assert!(output.status.success(), "Dry run failed: {:?}", output);
+    assert!(output.status.success(), "Dry run failed: {output:?}");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
     // SDK should be marked as affected
@@ -2241,7 +2241,7 @@ version = "1.0.0"
         .output()
         .unwrap();
 
-    assert!(output.status.success(), "Command failed: {:?}", output);
+    assert!(output.status.success(), "Command failed: {output:?}");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
 


### PR DESCRIPTION
## Summary

- use captured format arguments in three integration-test assertion messages
- unblock the v0.7.0 release verifier under Rust 1.88 Clippy

## Validation

- `rustup run 1.88.0 cargo fmt --all -- --check`
- `rustup run 1.88.0 cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run 1.88.0 cargo test --locked --all-targets --all-features` (512 passed)