### PR TITLE
fix: audit releases on stable Rust

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,12 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy --locked --all-targets --all-features -- -D warnings
       - run: cargo test --locked --all-targets --all-features
+      # cargo-audit's own dependencies may require a newer compiler than Aster's
+      # MSRV. Keep Aster validation on 1.88, then install and run the audit tool
+      # with the current stable toolchain.
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+        with:
+          toolchain: stable
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- keep Aster format, Clippy, tests, and release builds pinned to Rust 1.88
- switch to current stable only before installing and running cargo-audit
- avoid cargo-audit installer dependency MSRV drift blocking releases

## Validation
- `actionlint .github/workflows/release.yml`
- prior v0.7.0 release run passed format, Rust 1.88 Clippy, and all tests before failing only while installing cargo-audit on Rust 1.88