### PR TITLE
fix: skip unavailable private release attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,7 @@ jobs:
           cd release-assets
           sha256sum ./* | sed 's#  \./#  #' > ../SHA256SUMS
       - uses: actions/attest-build-provenance@96b4a1ef7235a096b17240c259729fdd70c83d45 # v2
+        if: github.event.repository.visibility == 'public'
         with:
           subject-path: release-assets/*
       - uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2


### PR DESCRIPTION
## Summary
- create build provenance attestations only for public repositories
- allow private repositories on plans without GitHub attestations to publish release assets
- keep checksums, platform builds, package smoke tests, and release publication unchanged

## Validation
- `actionlint .github/workflows/release.yml`
- v0.7.0 release run 30597269525 passed verification and every platform/package build, then failed only because attestations are unavailable for the private ArchAstro organization plan