### PR TITLE
fix: restore private Homebrew downloads

### DIFF
--- a/.github/homebrew/aster.rb.template
+++ b/.github/homebrew/aster.rb.template
@@ -1,3 +1,50 @@
+require "download_strategy"
+
+class GitHubPrivateRepositoryReleaseDownloadStrategy < CurlDownloadStrategy
+  def initialize(url, name, version, **meta)
+    super
+    parse_url_pattern
+    set_github_token
+  end
+
+  def parse_url_pattern
+    url_pattern = %r{https://github\.com/([^/]+)/([^/]+)/releases/download/([^/]+)/(\S+)}
+    unless @url =~ url_pattern
+      raise CurlDownloadStrategyError, "Invalid GitHub release URL pattern"
+    end
+    _, @owner, @repo, @tag, @filename = *@url.match(url_pattern)
+  end
+
+  def set_github_token
+    @github_token = ENV["HOMEBREW_GITHUB_API_TOKEN"]
+    unless @github_token
+      raise CurlDownloadStrategyError, "HOMEBREW_GITHUB_API_TOKEN is required"
+    end
+  end
+
+  def _fetch(url:, resolved_url:, timeout:)
+    api_url = "https://api.github.com/repos/#{@owner}/#{@repo}/releases/tags/#{@tag}"
+    assets_json = Utils::Curl.curl_output(
+      "--header", "Authorization: token #{@github_token}",
+      "--header", "Accept: application/vnd.github.v3+json",
+      api_url
+    ).stdout
+    require "json"
+    release = JSON.parse(assets_json)
+    asset = release["assets"].find { |candidate| candidate["name"] == @filename }
+    unless asset
+      raise CurlDownloadStrategyError, "Asset #{@filename} not found in release #{@tag}"
+    end
+    curl_download(
+      "--header", "Authorization: token #{@github_token}",
+      "--header", "Accept: application/octet-stream",
+      asset["url"],
+      to: temporary_path,
+      timeout: timeout
+    )
+  end
+end
+
 class Aster < Formula
   desc "Build orchestration for polyglot monorepos"
   homepage "https://github.com/ArchAstro/aster"
@@ -6,17 +53,20 @@ class Aster < Formula
 
   on_macos do
     on_arm do
-      url "https://github.com/ArchAstro/aster/releases/download/v__VERSION__/aster-darwin-arm64.tar.gz"
+      url "https://github.com/ArchAstro/aster/releases/download/v__VERSION__/aster-darwin-arm64.tar.gz",
+          using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "__SHA_DARWIN_ARM64__"
     end
     on_intel do
-      url "https://github.com/ArchAstro/aster/releases/download/v__VERSION__/aster-darwin-x64.tar.gz"
+      url "https://github.com/ArchAstro/aster/releases/download/v__VERSION__/aster-darwin-x64.tar.gz",
+          using: GitHubPrivateRepositoryReleaseDownloadStrategy
       sha256 "__SHA_DARWIN_X64__"
     end
   end
 
   on_linux do
-    url "https://github.com/ArchAstro/aster/releases/download/v__VERSION__/aster-linux-x64.tar.gz"
+    url "https://github.com/ArchAstro/aster/releases/download/v__VERSION__/aster-linux-x64.tar.gz",
+        using: GitHubPrivateRepositoryReleaseDownloadStrategy
     sha256 "__SHA_LINUX_X64__"
   end
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,27 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  homebrew-formula:
+    name: Homebrew formula
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Render formula for the latest private release
+        run: |
+          brew tap-new --no-git aster-ci/private-release
+          formula="$(brew --repository aster-ci/private-release)/Formula/aster.rb"
+          sed \
+            -e "s/__VERSION__/0.7.0/g" \
+            -e "s/__SHA_DARWIN_ARM64__/1d0a98bac39f4bea1194d6314247a7de40a2a5f3b9def1577342fff75c6d412e/g" \
+            -e "s/__SHA_DARWIN_X64__/ea2bfbba6a37674fe8fe5a47b4377d4cc601a3db6b75de593c424a2e909bb39e/g" \
+            -e "s/__SHA_LINUX_X64__/e8a42adbda5aa4da3f8edcc91b3bda4a7cf8e3758464ddfab3e0ff249ee47a8f/g" \
+            .github/homebrew/aster.rb.template > "${formula}"
+          ruby -c "${formula}"
+      - name: Fetch the private Apple Silicon release asset
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: brew fetch --force --formula aster-ci/private-release/aster
+
   linux-packages:
     name: Linux packages
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ aster affected test --base=main
 
 ### Homebrew
 
+The repository is private, so authenticate Homebrew's release download with a
+GitHub token that can read it:
+
 ```console
+export HOMEBREW_GITHUB_API_TOKEN="$(gh auth token)"
 brew install ArchAstro/tap/aster
 ```
 


### PR DESCRIPTION
## Summary
- restore the authenticated GitHub private-release download strategy removed during open-source preparation
- make every platform URL use the private strategy
- smoke-test the real v0.7.0 Apple Silicon asset in an isolated Homebrew tap
- document `HOMEBREW_GITHUB_API_TOKEN` setup

## Validation
- real authenticated `brew fetch` of v0.7.0 ARM archive
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --locked --no-deps --all-features`
- `cargo test --locked --all-targets --all-features` (512 passed)