### PR TITLE
feat: add JVM and Ruby project support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "predicates",
  "ratatui",
  "regex",
+ "roxmltree",
  "serde",
  "serde_json",
  "sha2",
@@ -1181,6 +1182,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 toml = "0.8"
 regex = "1.10"
+roxmltree = "0.20"
 git2 = "0.21"
 console = "0.16"
 indicatif = "0.18"

--- a/README.md
+++ b/README.md
@@ -115,13 +115,17 @@ Use `aster --help` and `aster <command> --help` for the complete CLI reference.
 | Go | `go.mod` | deps, build, test, lint, clean |
 | Python | `pyproject.toml` | deps, build, test, lint, format, clean |
 | Elixir | `mix.exs` | deps, build, test, lint, format, clean |
-| Gradle/JVM | `settings.gradle[.kts]`, `build.gradle[.kts]` | deps, build, test, lint, format, clean |
-| Maven/JVM | `pom.xml` | deps, build, test, lint, format, clean |
+| Java | Gradle or Maven build files plus `.java` sources/plugins | deps, build, test, lint, format, clean |
+| Kotlin | Gradle or Maven build files plus `.kt` sources/plugins | deps, build, test, lint, format, clean |
 | Ruby | `Gemfile`, `*.gemspec` | deps, build, test, lint, format, dev, clean |
 
 Detected targets depend on the tools and scripts present in each project.
 Node.js projects use the `packageManager` field or lockfile to choose npm or
 pnpm. Workspace members inherit their workspace root's package manager.
+Java and Kotlin are detected independently from their build system, so one
+Gradle or Maven project may report either or both languages. Kotlin DSL files
+such as `build.gradle.kts` configure the build and do not by themselves make a
+project Kotlin. Use `--lang java` or `--lang kotlin` across either build system.
 Gradle and Maven projects prefer their checked-in wrappers and scope module
 targets to the native multi-project build or reactor, which remains responsible
 for ordering dependencies within that build. Pure aggregator roots and embedded

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Use `aster --help` and `aster <command> --help` for the complete CLI reference.
 | Elixir | `mix.exs` | deps, build, test, lint, format, clean |
 | Gradle/JVM | `settings.gradle[.kts]`, `build.gradle[.kts]` | deps, build, test, lint, format, clean |
 | Maven/JVM | `pom.xml` | deps, build, test, lint, format, clean |
+| Ruby | `Gemfile`, `*.gemspec` | deps, build, test, lint, format, dev, clean |
 
 Detected targets depend on the tools and scripts present in each project.
 Node.js projects use the `packageManager` field or lockfile to choose npm or
@@ -129,6 +130,12 @@ directory containing both Gradle and Maven configuration, Maven takes precedence
 so the project has one unambiguous Aster address. A colocated `package.json`
 similarly keeps the existing Node.js project rather than creating a conflicting
 Gradle address.
+Ruby projects use Bundler when a Gemfile is present and detect conventional gem builds,
+Rake/Minitest, RSpec, Rails tests and servers, and RuboCop. A colocated gemspec
+is the canonical marker for a packaged gem, while Rails and gem projects take
+precedence over colocated JavaScript asset packages at the same directory-based
+Aster address. Ruby config is parsed statically and is never evaluated during
+discovery.
 
 ## Project configuration
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,20 @@ Use `aster --help` and `aster <command> --help` for the complete CLI reference.
 | Go | `go.mod` | deps, build, test, lint, clean |
 | Python | `pyproject.toml` | deps, build, test, lint, format, clean |
 | Elixir | `mix.exs` | deps, build, test, lint, format, clean |
+| Gradle/JVM | `settings.gradle[.kts]`, `build.gradle[.kts]` | deps, build, test, lint, format, clean |
+| Maven/JVM | `pom.xml` | deps, build, test, lint, format, clean |
 
 Detected targets depend on the tools and scripts present in each project.
 Node.js projects use the `packageManager` field or lockfile to choose npm or
 pnpm. Workspace members inherit their workspace root's package manager.
+Gradle and Maven projects prefer their checked-in wrappers and scope module
+targets to the native multi-project build or reactor, which remains responsible
+for ordering dependencies within that build. Pure aggregator roots and embedded
+Maven integration-test fixtures are not exposed as standalone projects. In a
+directory containing both Gradle and Maven configuration, Maven takes precedence
+so the project has one unambiguous Aster address. A colocated `package.json`
+similarly keeps the existing Node.js project rather than creating a conflicting
+Gradle address.
 
 ## Project configuration
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -106,7 +106,7 @@ pub enum Commands {
         /// Directory to scope listing to (e.g., "services/" or ".")
         path: Option<String>,
 
-        /// Filter by language/build plugin (e.g., nodejs, ruby, gradle, maven)
+        /// Filter by source language (e.g., nodejs, ruby, java, kotlin)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },
@@ -164,7 +164,7 @@ pub enum Commands {
         #[arg(long)]
         warnings_as_errors: bool,
 
-        /// Filter by language/build plugin (e.g., nodejs, ruby, gradle, maven)
+        /// Filter by source language (e.g., nodejs, ruby, java, kotlin)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },
@@ -188,7 +188,7 @@ pub enum Commands {
         #[arg(long)]
         no_deps: bool,
 
-        /// Filter by language/build plugin (e.g., nodejs, python, gradle, maven)
+        /// Filter by source language (e.g., nodejs, python, java, kotlin)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -31,7 +31,7 @@ use super::output::OutputMode;
     --no-deps             Skip running dependencies first
     --dependents          Also run projects that depend on selected ones
     --warnings-as-errors  Treat warnings as errors (for supported targets)
-    --lang <langs>        Filter by language (e.g., --lang nodejs,python)
+    --lang <langs>        Filter by language (e.g., --lang nodejs,ruby)
 
   Use `aster target <name>` when a target name conflicts with a built-in command.
 
@@ -106,7 +106,7 @@ pub enum Commands {
         /// Directory to scope listing to (e.g., "services/" or ".")
         path: Option<String>,
 
-        /// Filter by language/build plugin (e.g., nodejs, python, gradle, maven)
+        /// Filter by language/build plugin (e.g., nodejs, ruby, gradle, maven)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },
@@ -164,7 +164,7 @@ pub enum Commands {
         #[arg(long)]
         warnings_as_errors: bool,
 
-        /// Filter by language/build plugin (e.g., nodejs, python, gradle, maven)
+        /// Filter by language/build plugin (e.g., nodejs, ruby, gradle, maven)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -106,7 +106,7 @@ pub enum Commands {
         /// Directory to scope listing to (e.g., "services/" or ".")
         path: Option<String>,
 
-        /// Filter by language (e.g., nodejs, python, rust, go, elixir)
+        /// Filter by language/build plugin (e.g., nodejs, python, gradle, maven)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },
@@ -164,7 +164,7 @@ pub enum Commands {
         #[arg(long)]
         warnings_as_errors: bool,
 
-        /// Filter by language (e.g., nodejs, python, rust, go, elixir)
+        /// Filter by language/build plugin (e.g., nodejs, python, gradle, maven)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },
@@ -188,7 +188,7 @@ pub enum Commands {
         #[arg(long)]
         no_deps: bool,
 
-        /// Filter by language (e.g., nodejs, python, rust, go, elixir)
+        /// Filter by language/build plugin (e.g., nodejs, python, gradle, maven)
         #[arg(long, value_delimiter = ',')]
         lang: Vec<String>,
     },

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -48,8 +48,13 @@ pub struct ProjectInfo {
     pub address: String,
     /// Relative path from workspace root
     pub path: String,
-    /// Plugin that discovered this project
+    /// Internal plugin that discovered and executes this project
     pub plugin: String,
+    /// Source languages used by the project
+    pub languages: Vec<String>,
+    /// Build system used by the project, when distinct from its language
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub build_system: Option<String>,
     /// Available targets and their commands
     pub targets: HashMap<String, String>,
 }
@@ -260,6 +265,8 @@ mod tests {
             address: "//services/api".to_string(),
             path: "services/api".to_string(),
             plugin: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             targets,
         };
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -45,7 +45,7 @@ pub struct RunArgs {
     pub json: bool,
     /// Show full output for failed targets
     pub full_logs: bool,
-    /// Filter by language/plugin name (e.g., "nodejs", "python")
+    /// Filter by source language (e.g., "nodejs", "python", "java", "kotlin")
     pub lang: Vec<String>,
 }
 
@@ -340,7 +340,7 @@ pub fn select_projects<'a>(
 
     // Apply language filter
     if !args.lang.is_empty() {
-        result.retain(|p| args.lang.contains(&p.plugin_name));
+        result.retain(|p| p.has_any_language(&args.lang));
     }
 
     Ok(result)
@@ -713,6 +713,8 @@ mod tests {
                 dependencies: vec![],
                 targets: HashMap::new(),
                 plugin_name: "nodejs".to_string(),
+                languages: vec!["nodejs".to_string()],
+                build_system: None,
                 relative_path: PathBuf::from(relative_path),
             }
         }
@@ -1120,16 +1122,22 @@ mod tests {
                 dependencies: vec![],
                 targets: HashMap::new(),
                 plugin_name: plugin.to_string(),
+                languages: vec![plugin.to_string()],
+                build_system: None,
                 relative_path: PathBuf::from(relative_path),
             }
         }
 
         #[test]
         fn test_select_projects_lang_filter() {
+            let mut mixed_jvm = make_project_with_lang("mixed-jvm", "src/mixed", "gradle");
+            mixed_jvm.languages = vec!["java".to_string(), "kotlin".to_string()];
+            mixed_jvm.build_system = Some("gradle".to_string());
             let projects = vec![
                 make_project_with_lang("node-app", "src/node-app", "nodejs"),
                 make_project_with_lang("py-app", "src/py-app", "python"),
                 make_project_with_lang("rust-lib", "src/rust-lib", "rust"),
+                mixed_jvm,
             ];
             let graph = build_graph(&projects).unwrap();
             let workspace_root = Path::new("/workspace");
@@ -1138,7 +1146,7 @@ mod tests {
             let args = RunArgs {
                 target: "test".to_string(),
                 all: true,
-                lang: vec!["nodejs".to_string(), "python".to_string()],
+                lang: vec!["nodejs".to_string(), "kotlin".to_string()],
                 ..Default::default()
             };
 
@@ -1147,7 +1155,8 @@ mod tests {
             assert_eq!(selected.len(), 2);
             let names: Vec<&str> = selected.iter().map(|p| p.metadata.name.as_str()).collect();
             assert!(names.contains(&"node-app"));
-            assert!(names.contains(&"py-app"));
+            assert!(names.contains(&"mixed-jvm"));
+            assert!(!names.contains(&"py-app"));
             assert!(!names.contains(&"rust-lib"));
         }
 

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -42,6 +42,10 @@ pub struct DiscoveredProject {
     pub targets: HashMap<String, Target>,
     /// Which plugin discovered this project
     pub plugin_name: String,
+    /// Source languages used by this project (for example, Java and Kotlin)
+    pub languages: Vec<String>,
+    /// Build system used by this project when distinct from its language
+    pub build_system: Option<String>,
     /// Path relative to workspace root (for addressing)
     pub relative_path: PathBuf,
 }
@@ -55,6 +59,8 @@ struct PartialProject {
     custom_targets: HashMap<String, crate::config::TargetConfig>,
     explicit_target_dependencies: Vec<(String, String)>,
     plugin_name: String,
+    languages: Vec<String>,
+    build_system: Option<String>,
     relative_path: PathBuf,
 }
 
@@ -145,6 +151,10 @@ pub fn discover_projects(
             )
         })?;
 
+        let languages = plugin
+            .languages(project_dir, &config_path)
+            .with_context(|| format!("Failed to detect languages for {}", config_path.display()))?;
+
         // Collect custom targets from aster.toml (if exists)
         let mut custom_targets = HashMap::new();
         let mut explicit_target_dependencies = Vec::new();
@@ -220,6 +230,8 @@ pub fn discover_projects(
             custom_targets,
             explicit_target_dependencies,
             plugin_name: plugin.name().to_string(),
+            languages,
+            build_system: plugin.build_system().map(str::to_string),
             relative_path,
         });
     }
@@ -267,6 +279,8 @@ pub fn discover_projects(
             dependencies: partial.dependencies,
             targets,
             plugin_name: partial.plugin_name,
+            languages: partial.languages,
+            build_system: partial.build_system,
             relative_path: partial.relative_path,
         });
     }
@@ -278,6 +292,18 @@ pub fn discover_projects(
     normalize_target_dependencies(&mut projects, &explicit_target_dependencies)?;
 
     Ok(projects)
+}
+
+impl DiscoveredProject {
+    /// Whether this project contains the requested source language.
+    pub fn has_language(&self, language: &str) -> bool {
+        self.languages.iter().any(|candidate| candidate == language)
+    }
+
+    /// Whether this project contains any of the requested source languages.
+    pub fn has_any_language(&self, languages: &[String]) -> bool {
+        languages.iter().any(|language| self.has_language(language))
+    }
 }
 
 fn validate_project_addresses(projects: &[DiscoveredProject]) -> Result<()> {
@@ -629,6 +655,8 @@ dependencies { implementation(project(":shared")) }
             .find(|project| project.relative_path == Path::new("app"))
             .unwrap();
         assert_eq!(app.plugin_name, "gradle");
+        assert_eq!(app.languages, vec!["java"]);
+        assert_eq!(app.build_system.as_deref(), Some("gradle"));
         assert_eq!(app.targets["build"].command, "./gradlew :app:build");
         assert!(app.dependencies.is_empty());
         assert_eq!(app.targets["build"].depends_on, vec!["//app:deps"]);
@@ -671,6 +699,8 @@ dependencies { implementation(project(":shared")) }
             .find(|project| project.relative_path == Path::new("app"))
             .unwrap();
         assert_eq!(app.plugin_name, "maven");
+        assert_eq!(app.languages, vec!["java"]);
+        assert_eq!(app.build_system.as_deref(), Some("maven"));
         assert_eq!(
             app.targets["build"].command,
             "./mvnw -pl :app -am package -DskipTests"

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -73,13 +73,6 @@ pub fn discover_projects(
     let workspace_config = WorkspaceConfig::load(workspace_root)?;
     let ignore_set = build_ignore_set(&workspace_config.ignore)?;
 
-    // Collect all marker files we're looking for
-    let marker_files: Vec<&str> = registry
-        .plugins()
-        .iter()
-        .flat_map(|p| p.marker_files().iter().copied())
-        .collect();
-
     let mut partial_projects: Vec<PartialProject> = Vec::new();
 
     // Phase 1: Walk the directory tree and collect project metadata + dependencies
@@ -106,10 +99,6 @@ pub fn discover_projects(
             Some(name) => name,
             None => continue,
         };
-
-        if !marker_files.contains(&file_name) {
-            continue;
-        }
 
         // Find the plugin that handles this marker
         let plugin = match registry.find_by_marker(file_name) {
@@ -567,6 +556,92 @@ mod tests {
         assert!(names.contains(&"api"));
         assert!(names.contains(&"web"));
         assert!(names.contains(&"shared"));
+    }
+
+    #[test]
+    fn discovers_gradle_kotlin_dsl_modules_without_flattening_native_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::write(
+            tmp.path().join("settings.gradle.kts"),
+            r#"rootProject.name = "sample"
+include("shared", "app")
+"#,
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("gradlew"), "").unwrap();
+
+        for module in ["shared", "app"] {
+            let directory = tmp.path().join(module);
+            std::fs::create_dir_all(directory.join("src/main/java")).unwrap();
+            std::fs::write(
+                directory.join(format!("{module}.gradle.kts")),
+                if module == "app" {
+                    r#"plugins { java }
+dependencies { implementation(project(":shared")) }
+"#
+                } else {
+                    "plugins { java }\n"
+                },
+            )
+            .unwrap();
+        }
+
+        let projects = discover_projects(tmp.path(), &PluginRegistry::with_all_plugins()).unwrap();
+        assert_eq!(projects.len(), 2);
+        let app = projects
+            .iter()
+            .find(|project| project.relative_path == Path::new("app"))
+            .unwrap();
+        assert_eq!(app.plugin_name, "gradle");
+        assert_eq!(app.targets["build"].command, "./gradlew :app:build");
+        assert!(app.dependencies.is_empty());
+        assert_eq!(app.targets["build"].depends_on, vec!["//app:deps"]);
+    }
+
+    #[test]
+    fn discovers_maven_reactor_modules_without_flattening_native_dependencies() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::write(
+            tmp.path().join("pom.xml"),
+            r#"<project>
+  <artifactId>sample-parent</artifactId>
+  <packaging>pom</packaging>
+  <modules><module>shared</module><module>app</module></modules>
+</project>"#,
+        )
+        .unwrap();
+        std::fs::write(tmp.path().join("mvnw"), "").unwrap();
+
+        for module in ["shared", "app"] {
+            let directory = tmp.path().join(module);
+            std::fs::create_dir_all(directory.join("src/main/java")).unwrap();
+            let dependencies = if module == "app" {
+                "<dependencies><dependency><groupId>dev.example</groupId><artifactId>shared</artifactId></dependency></dependencies>"
+            } else {
+                ""
+            };
+            std::fs::write(
+                directory.join("pom.xml"),
+                format!("<project><artifactId>{module}</artifactId>{dependencies}</project>"),
+            )
+            .unwrap();
+        }
+
+        let projects = discover_projects(tmp.path(), &PluginRegistry::with_all_plugins()).unwrap();
+        assert_eq!(projects.len(), 2);
+        let app = projects
+            .iter()
+            .find(|project| project.relative_path == Path::new("app"))
+            .unwrap();
+        assert_eq!(app.plugin_name, "maven");
+        assert_eq!(
+            app.targets["build"].command,
+            "./mvnw -pl :app -am package -DskipTests"
+        );
+        assert!(app.dependencies.is_empty());
+        assert_eq!(app.targets["build"].depends_on, vec!["//app:deps"]);
     }
 
     #[test]

--- a/src/discovery/scanner.rs
+++ b/src/discovery/scanner.rs
@@ -228,6 +228,7 @@ pub fn discover_projects(
     // This must happen BEFORE target detection so dependencies are resolved correctly
     resolve_umbrella_dependencies_partial(&mut partial_projects);
     resolve_uv_workspace_dependencies_partial(&mut partial_projects);
+    resolve_ruby_workspace_dependencies_partial(&mut partial_projects);
 
     // Phase 3: Detect targets with resolved dependencies
     let mut projects: Vec<DiscoveredProject> = Vec::new();
@@ -430,6 +431,40 @@ fn resolve_uv_workspace_dependencies_partial(projects: &mut [PartialProject]) {
                 }
             }
         }
+    }
+}
+
+/// Resolve gemspec runtime dependencies to sibling gems in the same workspace.
+/// Unmatched names are ordinary remote gems and are removed: LocalDependency
+/// represents only relationships Aster can resolve within this checkout.
+fn resolve_ruby_workspace_dependencies_partial(projects: &mut [PartialProject]) {
+    let name_to_address: HashMap<String, String> = projects
+        .iter()
+        .filter(|project| project.plugin_name == "ruby")
+        .map(|project| {
+            (
+                project.metadata.name.clone(),
+                format!("//{}", project.relative_path.display()),
+            )
+        })
+        .collect();
+
+    for project in projects
+        .iter_mut()
+        .filter(|project| project.plugin_name == "ruby")
+    {
+        project.dependencies.retain_mut(|dependency| {
+            let path = dependency.path.to_string_lossy();
+            let Some(name) = path.strip_prefix("ruby_workspace:") else {
+                return true;
+            };
+            if let Some(address) = name_to_address.get(name) {
+                dependency.path = PathBuf::from(address);
+                true
+            } else {
+                false
+            }
+        });
     }
 }
 
@@ -1583,5 +1618,48 @@ end
             core.dependencies[0].path,
             std::path::PathBuf::from("//src/elixir/config")
         );
+    }
+
+    #[test]
+    fn discovers_ruby_sibling_gems_and_resolves_runtime_dependencies_by_name() {
+        use crate::plugins::RubyPlugin;
+
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        for (directory, name, dependency) in [
+            ("gems/shared", "shared", None),
+            ("gems/app", "app", Some("shared")),
+        ] {
+            let project = tmp.path().join(directory);
+            std::fs::create_dir_all(project.join("test")).unwrap();
+            std::fs::write(project.join("Gemfile"), "gemspec\n").unwrap();
+            std::fs::write(
+                project.join(format!("{name}.gemspec")),
+                format!(
+                    "Gem::Specification.new do |s|\n  s.name = '{name}'\n{}end\n",
+                    dependency
+                        .map(|value| format!("  s.add_dependency '{value}'\n"))
+                        .unwrap_or_default()
+                ),
+            )
+            .unwrap();
+            std::fs::write(
+                project.join("Rakefile"),
+                "require 'rake/testtask'\nRake::TestTask.new\n",
+            )
+            .unwrap();
+        }
+
+        let mut registry = PluginRegistry::new();
+        registry.register(Box::new(RubyPlugin));
+        let projects = discover_projects(tmp.path(), &registry).unwrap();
+        assert_eq!(projects.len(), 2);
+        let app = projects
+            .iter()
+            .find(|project| project.metadata.name == "app")
+            .unwrap();
+        assert_eq!(app.dependencies.len(), 1);
+        assert_eq!(app.dependencies[0].path, Path::new("//gems/shared"));
+        assert_eq!(app.targets["test"].command, "bundle exec rake test");
     }
 }

--- a/src/executor/logs.rs
+++ b/src/executor/logs.rs
@@ -73,6 +73,20 @@ impl LogStore {
         Ok(Some(run))
     }
 
+    /// Remove the previous run log before executing native build tools.
+    ///
+    /// Some repositories lint every file under their checkout. Keeping a
+    /// captured build log in-tree while the next build runs can make the build
+    /// inspect Aster's output as if it were source.
+    pub fn clear_latest(&self) -> anyhow::Result<()> {
+        let latest_path = self.log_dir.join("latest.json");
+        match fs::remove_file(latest_path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     /// Get the log for a specific target from the latest run
     pub fn get_target_log(&self, address: &str) -> anyhow::Result<Option<TargetLog>> {
         let run = match self.load_latest()? {
@@ -132,6 +146,23 @@ mod tests {
 
         let result = store.load_latest().unwrap();
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_clear_latest_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let store = LogStore::new(tmp.path());
+        let run = RunLog {
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            target: "test".to_string(),
+            results: vec![],
+        };
+        store.store(&run).unwrap();
+        assert!(store.load_latest().unwrap().is_some());
+
+        store.clear_latest().unwrap();
+        store.clear_latest().unwrap();
+        assert!(store.load_latest().unwrap().is_none());
     }
 
     #[test]

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -1469,6 +1469,8 @@ mod tests {
             dependencies: vec![],
             targets,
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(relative_path),
         }
     }
@@ -1851,6 +1853,8 @@ mod tests {
             dependencies: vec![],
             targets: targets_a,
             plugin_name: "elixir".to_string(),
+            languages: vec!["elixir".to_string()],
+            build_system: None,
             relative_path: PathBuf::from("a"),
         };
         let project_b = DiscoveredProject {
@@ -1863,6 +1867,8 @@ mod tests {
             dependencies: vec![],
             targets: targets_b,
             plugin_name: "elixir".to_string(),
+            languages: vec!["elixir".to_string()],
+            build_system: None,
             relative_path: PathBuf::from("b"),
         };
 
@@ -1934,6 +1940,8 @@ mod tests {
             dependencies: vec![],
             targets: targets_a,
             plugin_name: "elixir".to_string(),
+            languages: vec!["elixir".to_string()],
+            build_system: None,
             relative_path: PathBuf::from("a"),
         };
         let project_b = DiscoveredProject {
@@ -1946,6 +1954,8 @@ mod tests {
             dependencies: vec![],
             targets: targets_b,
             plugin_name: "elixir".to_string(),
+            languages: vec!["elixir".to_string()],
+            build_system: None,
             relative_path: PathBuf::from("b"),
         };
 

--- a/src/executor/runner.rs
+++ b/src/executor/runner.rs
@@ -328,6 +328,13 @@ impl<'a> Executor<'a> {
             return Vec::new();
         }
 
+        if self.output_mode != OutputMode::Json {
+            let log_store = LogStore::new(self.workspace_root);
+            if let Err(error) = log_store.clear_latest() {
+                eprintln!("[aster] Warning: Failed to clear previous logs: {error}");
+            }
+        }
+
         let show_progress = matches!(self.output_mode, OutputMode::Normal | OutputMode::Verbose);
         let verbose_progress = self.output_mode == OutputMode::Verbose;
         let show_output = matches!(self.output_mode, OutputMode::Normal | OutputMode::Verbose);

--- a/src/git/file_owner.rs
+++ b/src/git/file_owner.rs
@@ -98,6 +98,8 @@ mod tests {
                 .collect(),
             targets: HashMap::new(),
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(relative_path),
         }
     }

--- a/src/graph/builder.rs
+++ b/src/graph/builder.rs
@@ -299,6 +299,8 @@ mod tests {
                 .collect(),
             targets: HashMap::new(),
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(relative_path),
         }
     }

--- a/src/graph/cycles.rs
+++ b/src/graph/cycles.rs
@@ -119,6 +119,8 @@ mod tests {
                 .collect(),
             targets: HashMap::new(),
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(relative_path),
         }
     }

--- a/src/graph/path.rs
+++ b/src/graph/path.rs
@@ -63,6 +63,8 @@ mod tests {
                 .collect(),
             targets: HashMap::new(),
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(relative_path),
         }
     }

--- a/src/graph/targets.rs
+++ b/src/graph/targets.rs
@@ -248,6 +248,8 @@ mod tests {
                 })
                 .collect(),
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(relative_path),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,10 +23,7 @@ use aster::executor::{
 };
 use aster::git::{affected_with_dependents, files_to_projects, AffectedDetector, AffectedIgnore};
 use aster::graph::{build_graph, build_target_graph, find_cycle, format_path};
-use aster::plugins::{
-    ElixirPlugin, GoPlugin, NodeJsPlugin, PluginRegistry, PythonPlugin, RustPlugin, Target,
-    TargetCapability,
-};
+use aster::plugins::{PluginRegistry, Target, TargetCapability};
 use chrono::{DateTime, Utc};
 use globset::{Glob, GlobMatcher};
 use std::collections::{HashMap, HashSet};
@@ -72,12 +69,7 @@ fn run() -> Result<()> {
     }
 
     // Set up plugin registry with all language plugins
-    let mut registry = PluginRegistry::new();
-    registry.register(Box::new(NodeJsPlugin));
-    registry.register(Box::new(ElixirPlugin));
-    registry.register(Box::new(PythonPlugin));
-    registry.register(Box::new(GoPlugin));
-    registry.register(Box::new(RustPlugin));
+    let registry = PluginRegistry::with_all_plugins();
 
     // Discover projects
     let projects =
@@ -662,12 +654,7 @@ fn run() -> Result<()> {
                 let mut effective_primary_addrs = primary_addrs.clone();
 
                 // Create plugin registry for capability handling
-                let mut registry = PluginRegistry::new();
-                registry.register(Box::new(NodeJsPlugin));
-                registry.register(Box::new(PythonPlugin));
-                registry.register(Box::new(ElixirPlugin));
-                registry.register(Box::new(GoPlugin));
-                registry.register(Box::new(RustPlugin));
+                let registry = PluginRegistry::with_all_plugins();
 
                 for project in &ordered {
                     let project_addr = format!("//{}", project.relative_path.display());
@@ -1099,12 +1086,7 @@ fn run() -> Result<()> {
                 let mut command_overrides: HashMap<String, String> = HashMap::new();
 
                 // Create plugin registry for capability handling
-                let mut registry = PluginRegistry::new();
-                registry.register(Box::new(NodeJsPlugin));
-                registry.register(Box::new(PythonPlugin));
-                registry.register(Box::new(ElixirPlugin));
-                registry.register(Box::new(GoPlugin));
-                registry.register(Box::new(RustPlugin));
+                let registry = PluginRegistry::with_all_plugins();
 
                 for project in &ordered {
                     let project_addr = format!("//{}", project.relative_path.display());
@@ -1258,12 +1240,7 @@ fn handle_init(cwd: &std::path::Path, verbose: bool) -> Result<()> {
     println!("Created {}", aster_toml_path.display());
 
     // Set up plugin registry
-    let mut registry = PluginRegistry::new();
-    registry.register(Box::new(NodeJsPlugin));
-    registry.register(Box::new(ElixirPlugin));
-    registry.register(Box::new(PythonPlugin));
-    registry.register(Box::new(GoPlugin));
-    registry.register(Box::new(RustPlugin));
+    let registry = PluginRegistry::with_all_plugins();
 
     // Discover projects
     let projects =
@@ -1353,12 +1330,7 @@ fn handle_watch(
         return Err(anyhow::anyhow!("{cycle}"));
     }
 
-    let mut registry = PluginRegistry::new();
-    registry.register(Box::new(NodeJsPlugin));
-    registry.register(Box::new(ElixirPlugin));
-    registry.register(Box::new(PythonPlugin));
-    registry.register(Box::new(GoPlugin));
-    registry.register(Box::new(RustPlugin));
+    let registry = PluginRegistry::with_all_plugins();
 
     let plan = WatchPlan::build(&resolved, &projects, &graph, &registry)?;
 
@@ -1470,6 +1442,12 @@ fn detect_plugin_for_directory(dir: &Path) -> Option<String> {
         ("go.mod", "go"),
         ("pyproject.toml", "python"),
         ("mix.exs", "elixir"),
+        ("Cargo.toml", "rust"),
+        ("pom.xml", "maven"),
+        ("settings.gradle.kts", "gradle"),
+        ("settings.gradle", "gradle"),
+        ("build.gradle.kts", "gradle"),
+        ("build.gradle", "gradle"),
     ];
 
     for (marker, plugin_name) in markers {
@@ -1585,6 +1563,32 @@ fn generate_aster_toml_content(
 
 # [targets.dialyzer]
 # command = "mix dialyzer"
+# depends_on = ["//self:build"]
+"#
+        }
+        Some("gradle") => {
+            r#"# Target configuration
+# Simple format - just override the command:
+# [targets]
+# test = "./gradlew test"
+# lint = "./gradlew check"
+
+# Rich format - full control over target behavior:
+# [targets.integration]
+# command = "./gradlew integrationTest"
+# depends_on = ["//self:build"]
+"#
+        }
+        Some("maven") => {
+            r#"# Target configuration
+# Simple format - just override the command:
+# [targets]
+# test = "./mvnw test"
+# lint = "./mvnw verify -DskipTests"
+
+# Rich format - full control over target behavior:
+# [targets.integration]
+# command = "./mvnw verify -Pintegration"
 # depends_on = ["//self:build"]
 "#
         }
@@ -1802,7 +1806,9 @@ fn apply_warnings_as_errors(
 /// Format a timestamp as a human-readable relative time
 ///
 /// Known language/plugin names for --lang validation
-const VALID_LANGS: &[&str] = &["nodejs", "python", "rust", "go", "elixir"];
+const VALID_LANGS: &[&str] = &[
+    "nodejs", "python", "rust", "go", "elixir", "gradle", "maven",
+];
 
 /// Validate that all --lang values are known plugin names
 fn validate_lang_filter(langs: &[String]) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn run() -> Result<()> {
             let filtered_projects: Vec<&DiscoveredProject> = if !lang.is_empty() {
                 filtered_projects
                     .into_iter()
-                    .filter(|p| lang.contains(&p.plugin_name))
+                    .filter(|p| p.has_any_language(&lang))
                     .collect()
             } else {
                 filtered_projects
@@ -132,6 +132,8 @@ fn run() -> Result<()> {
                             address: format!("//{}", p.relative_path.display()),
                             path: p.relative_path.display().to_string(),
                             plugin: p.plugin_name.clone(),
+                            languages: p.languages.clone(),
+                            build_system: p.build_system.clone(),
                             targets,
                         }
                     })
@@ -464,7 +466,7 @@ fn run() -> Result<()> {
                     let addr = format!("//{}", p.relative_path.display());
                     affected_addrs.contains(&addr)
                 })
-                .filter(|p| lang.is_empty() || lang.contains(&p.plugin_name))
+                .filter(|p| lang.is_empty() || p.has_any_language(&lang))
                 .collect();
 
             if affected_projects.is_empty() {
@@ -808,7 +810,7 @@ fn run() -> Result<()> {
                         if let Some((proj_addr, _)) = t.rsplit_once(':') {
                             project_map
                                 .get(proj_addr)
-                                .map(|p| lang.contains(&p.plugin_name))
+                                .map(|p| p.has_any_language(&lang))
                                 .unwrap_or(true)
                         } else {
                             true
@@ -1301,20 +1303,23 @@ fn handle_watch(
 
     // Apply language filter by dropping targets from non-matching projects.
     if !lang.is_empty() {
-        let project_lang: HashMap<String, String> = projects
+        let project_languages: HashMap<String, Vec<String>> = projects
             .iter()
             .map(|p| {
                 (
                     format!("//{}", p.relative_path.display()),
-                    p.plugin_name.clone(),
+                    p.languages.clone(),
                 )
             })
             .collect();
         resolved.retain(|addr| {
             let project_addr = addr.rsplit_once(':').map(|(p, _)| p).unwrap_or(addr);
-            project_lang
+            project_languages
                 .get(project_addr)
-                .map(|pl| lang.contains(pl))
+                .map(|project_languages| {
+                    lang.iter()
+                        .any(|language| project_languages.contains(language))
+                })
                 .unwrap_or(false)
         });
         if resolved.is_empty() {
@@ -1833,12 +1838,12 @@ fn apply_warnings_as_errors(
 
 /// Format a timestamp as a human-readable relative time
 ///
-/// Known language/plugin names for --lang validation
+/// Known source-language names for --lang validation
 const VALID_LANGS: &[&str] = &[
-    "nodejs", "python", "rust", "go", "elixir", "gradle", "maven", "ruby",
+    "nodejs", "python", "rust", "go", "elixir", "java", "kotlin", "ruby",
 ];
 
-/// Validate that all --lang values are known plugin names
+/// Validate that all --lang values are known source languages
 fn validate_lang_filter(langs: &[String]) -> Result<()> {
     for lang in langs {
         if !VALID_LANGS.contains(&lang.as_str()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1438,6 +1438,7 @@ fn handle_project_init(
 /// Detect which language plugin applies to a directory
 fn detect_plugin_for_directory(dir: &Path) -> Option<String> {
     let markers = [
+        ("Gemfile", "ruby"),
         ("package.json", "nodejs"),
         ("go.mod", "go"),
         ("pyproject.toml", "python"),
@@ -1454,6 +1455,20 @@ fn detect_plugin_for_directory(dir: &Path) -> Option<String> {
         if dir.join(marker).exists() {
             return Some(plugin_name.to_string());
         }
+    }
+
+    if std::fs::read_dir(dir)
+        .into_iter()
+        .flatten()
+        .filter_map(std::result::Result::ok)
+        .any(|entry| {
+            entry
+                .path()
+                .extension()
+                .is_some_and(|extension| extension == "gemspec")
+        })
+    {
+        return Some("ruby".to_string());
     }
 
     None
@@ -1590,6 +1605,19 @@ fn generate_aster_toml_content(
 # [targets.integration]
 # command = "./mvnw verify -Pintegration"
 # depends_on = ["//self:build"]
+"#
+        }
+        Some("ruby") => {
+            r#"# Target configuration
+# Simple format - just override the command:
+# [targets]
+# test = "bundle exec rake test"
+# lint = "bundle exec rubocop"
+
+# Rich format - full control over target behavior:
+# [targets.integration]
+# command = "bundle exec rspec spec/integration"
+# depends_on = ["//self:deps"]
 "#
         }
         _ => {
@@ -1807,7 +1835,7 @@ fn apply_warnings_as_errors(
 ///
 /// Known language/plugin names for --lang validation
 const VALID_LANGS: &[&str] = &[
-    "nodejs", "python", "rust", "go", "elixir", "gradle", "maven",
+    "nodejs", "python", "rust", "go", "elixir", "gradle", "maven", "ruby",
 ];
 
 /// Validate that all --lang values are known plugin names

--- a/src/plugins/gradle.rs
+++ b/src/plugins/gradle.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+use super::jvm;
 use super::{CacheInputs, LanguagePlugin, LocalDependency, ProjectMetadata, Target, TargetContext};
 
 static ROOT_NAME: LazyLock<Regex> = LazyLock::new(|| {
@@ -33,6 +34,46 @@ pub struct GradlePlugin;
 impl LanguagePlugin for GradlePlugin {
     fn name(&self) -> &str {
         "gradle"
+    }
+
+    fn languages(&self, project_dir: &Path, config_path: &Path) -> Result<Vec<String>> {
+        let mut languages = jvm::source_languages(project_dir);
+        let mut build_content = std::fs::read_to_string(config_path).unwrap_or_default();
+        for filename in ["build.gradle", "build.gradle.kts"] {
+            let sibling = project_dir.join(filename);
+            if sibling != config_path {
+                if let Ok(content) = std::fs::read_to_string(sibling) {
+                    build_content.push('\n');
+                    build_content.push_str(&content);
+                }
+            }
+        }
+
+        let has_java_plugin = build_content.contains("plugins { java")
+            || build_content.contains("apply plugin: 'java'")
+            || build_content.contains("apply plugin: \"java\"")
+            || build_content.contains("id(\"java\")")
+            || build_content.contains("id(\"java-library\")")
+            || build_content.contains("id 'java'")
+            || build_content.contains("id 'java-library'");
+        let has_kotlin_plugin = build_content.contains("org.jetbrains.kotlin")
+            || build_content.contains("kotlin(\"jvm\")")
+            || build_content.contains("kotlin(\"multiplatform\")")
+            || build_content.contains("kotlin('jvm')")
+            || build_content.contains("kotlin('multiplatform')");
+
+        if has_java_plugin && !languages.iter().any(|language| language == "java") {
+            languages.push("java".to_string());
+        }
+        if has_kotlin_plugin && !languages.iter().any(|language| language == "kotlin") {
+            languages.push("kotlin".to_string());
+        }
+        languages.sort();
+        Ok(languages)
+    }
+
+    fn build_system(&self) -> Option<&str> {
+        Some("gradle")
     }
 
     fn marker_files(&self) -> &[&str] {

--- a/src/plugins/gradle.rs
+++ b/src/plugins/gradle.rs
@@ -1,0 +1,587 @@
+//! Gradle language plugin for JVM projects.
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use super::{CacheInputs, LanguagePlugin, LocalDependency, ProjectMetadata, Target, TargetContext};
+
+static ROOT_NAME: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?m)\brootProject\.name\s*=\s*["']([^"']+)["']"#)
+        .expect("valid Gradle root name regex")
+});
+static VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?m)^\s*version\s*=\s*["']([^"']+)["']"#).expect("valid Gradle version regex")
+});
+static PROJECT_DIR: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"project\s*\(\s*["'](:[^"']+)["']\s*\)\.projectDir\s*=\s*file\s*\(\s*["']([^"']+)["']\s*\)"#,
+    )
+    .expect("valid Gradle project directory regex")
+});
+static QUOTED_PROJECT_PATH: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"["'](:[A-Za-z0-9_.:-]+)["']"#).expect("valid Gradle project path regex")
+});
+static INCLUDE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?m)\binclude\s*(?:\(|\s)"#).expect("valid include regex"));
+
+/// Plugin for Gradle Groovy and Kotlin DSL builds.
+pub struct GradlePlugin;
+
+impl LanguagePlugin for GradlePlugin {
+    fn name(&self) -> &str {
+        "gradle"
+    }
+
+    fn marker_files(&self) -> &[&str] {
+        &[
+            "settings.gradle",
+            "settings.gradle.kts",
+            "build.gradle",
+            "build.gradle.kts",
+        ]
+    }
+
+    fn matches_marker(&self, filename: &str) -> bool {
+        filename.ends_with(".gradle") || filename.ends_with(".gradle.kts")
+    }
+
+    fn should_skip(&self, config_path: &Path) -> bool {
+        let Some(project_dir) = config_path.parent() else {
+            return true;
+        };
+        let Some(filename) = config_path.file_name().and_then(|name| name.to_str()) else {
+            return true;
+        };
+
+        // A directory with both build systems needs one unambiguous Aster
+        // address. Prefer the declarative Maven model; users can still override
+        // its targets in aster.toml.
+        if project_dir.join("pom.xml").is_file() || project_dir.join("package.json").is_file() {
+            return true;
+        }
+
+        if is_settings_file(filename) {
+            // Prefer Kotlin settings when both files are present.
+            if filename == "settings.gradle" && project_dir.join("settings.gradle.kts").is_file() {
+                return true;
+            }
+
+            // Pure aggregator roots are orchestration containers, not source
+            // projects. Their subprojects are discovered independently.
+            let content = std::fs::read_to_string(config_path).unwrap_or_default();
+            return !project_dir.join("src").is_dir() && INCLUDE.is_match(&content);
+        }
+
+        // A settings file is the canonical marker for a source-bearing root.
+        if has_settings_file(project_dir) {
+            return true;
+        }
+
+        if filename == "build.gradle" && project_dir.join("build.gradle.kts").is_file() {
+            return true;
+        }
+        if filename == "build.gradle" || filename == "build.gradle.kts" {
+            return false;
+        }
+
+        // Gradle permits arbitrary build filenames. Accept the widespread
+        // `<project-directory>.gradle(.kts)` convention while rejecting
+        // convention plugins and auxiliary scripts elsewhere in the tree.
+        let dir_name = project_dir.file_name().and_then(|name| name.to_str());
+        dir_name.is_none_or(|dir_name| {
+            filename != format!("{dir_name}.gradle") && filename != format!("{dir_name}.gradle.kts")
+        })
+    }
+
+    fn parse_project(&self, _root: &Path, config_path: &Path) -> Result<ProjectMetadata> {
+        let content = std::fs::read_to_string(config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+        let filename = config_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+
+        let name = if is_settings_file(filename) {
+            ROOT_NAME
+                .captures(&content)
+                .and_then(|captures| captures.get(1))
+                .map(|name| name.as_str().to_string())
+                .or_else(|| directory_name(config_path.parent()?))
+                .unwrap_or_else(|| "gradle-project".to_string())
+        } else {
+            gradle_build_name(filename)
+                .or_else(|| directory_name(config_path.parent()?))
+                .unwrap_or_else(|| "gradle-project".to_string())
+        };
+        let version = VERSION
+            .captures(&content)
+            .and_then(|captures| captures.get(1))
+            .map(|version| version.as_str().to_string());
+
+        Ok(ProjectMetadata { name, version })
+    }
+
+    fn parse_dependencies(&self, config_path: &Path) -> Result<Vec<LocalDependency>> {
+        // Gradle relationships are configuration- and task-specific. Scoped
+        // Gradle tasks preserve the native graph; unconditional Aster project
+        // edges can turn valid test/reporting relationships into false cycles.
+        let _ = config_path;
+        Ok(Vec::new())
+    }
+
+    fn detect_targets(&self, ctx: &TargetContext) -> Result<HashMap<String, Target>> {
+        let build_root = find_gradle_root(ctx.project_dir);
+        let task_prefix = gradle_task_prefix(&build_root, ctx.project_dir);
+        let runner = gradle_runner(&build_root);
+        let resource = native_build_resource("gradle", ctx.workspace_root, &build_root);
+        let working_dir = Some(build_root.clone());
+        // Gradle's task graph owns relationships between projects in the same
+        // build. Flattening configuration-specific project dependencies into
+        // unconditional Aster :build edges can invent cycles.
+        let base_dependencies = vec!["//self:deps".to_string()];
+
+        let task = |name: &str| {
+            if task_prefix.is_empty() {
+                name.to_string()
+            } else {
+                format!("{task_prefix}:{name}")
+            }
+        };
+        let make_target =
+            |command: String, depends_on: Vec<String>, invalidates_cache: bool| Target {
+                command,
+                depends_on,
+                capabilities: HashSet::new(),
+                files_glob: None,
+                stream: false,
+                cache: None,
+                invalidates_cache,
+                working_dir: working_dir.clone(),
+                exclusive_resources: vec![resource.clone()],
+            };
+
+        let mut targets = HashMap::new();
+        targets.insert(
+            "deps".to_string(),
+            make_target(format!("{runner} {}", task("dependencies")), vec![], false),
+        );
+        targets.insert(
+            "build".to_string(),
+            make_target(
+                format!("{runner} {}", task("build")),
+                base_dependencies.clone(),
+                false,
+            ),
+        );
+        targets.insert(
+            "test".to_string(),
+            make_target(
+                format!("{runner} {}", task("test")),
+                base_dependencies.clone(),
+                false,
+            ),
+        );
+        targets.insert(
+            "lint".to_string(),
+            make_target(
+                format!("{runner} {}", task("check")),
+                base_dependencies,
+                false,
+            ),
+        );
+
+        let build_content = std::fs::read_to_string(ctx.config_path).unwrap_or_default();
+        let root_content = std::fs::read_to_string(build_root.join("build.gradle.kts"))
+            .or_else(|_| std::fs::read_to_string(build_root.join("build.gradle")))
+            .unwrap_or_default();
+        let all_content = format!("{root_content}\n{build_content}");
+        let format_task = if all_content.contains("spotless") {
+            Some("spotlessApply")
+        } else if all_content.contains("ktlint") {
+            Some("ktlintFormat")
+        } else {
+            None
+        };
+        if let Some(format_task) = format_task {
+            targets.insert(
+                "format".to_string(),
+                make_target(
+                    format!("{runner} {}", task(format_task)),
+                    vec!["//self:deps".to_string()],
+                    false,
+                ),
+            );
+        }
+        targets.insert(
+            "clean".to_string(),
+            make_target(format!("{runner} {}", task("clean")), vec![], true),
+        );
+
+        Ok(targets)
+    }
+
+    fn cache_inputs(&self, target_name: &str) -> CacheInputs {
+        let mut inputs = CacheInputs {
+            source_globs: Vec::new(),
+            config_files: vec![
+                "settings.gradle".to_string(),
+                "settings.gradle.kts".to_string(),
+                "build.gradle".to_string(),
+                "build.gradle.kts".to_string(),
+                "gradle.properties".to_string(),
+                "gradle/libs.versions.toml".to_string(),
+                "gradle/wrapper/gradle-wrapper.properties".to_string(),
+            ],
+            env_vars: vec![
+                "JAVA_HOME".to_string(),
+                "GRADLE_OPTS".to_string(),
+                "ORG_GRADLE_PROJECT_*".to_string(),
+                "CI".to_string(),
+            ],
+        };
+        if target_name != "deps" {
+            inputs.source_globs = vec![
+                "src/**/*.java".to_string(),
+                "src/**/*.kt".to_string(),
+                "src/**/*.kts".to_string(),
+                "src/**/*.groovy".to_string(),
+                "src/**/*.scala".to_string(),
+                "src/main/resources/**/*".to_string(),
+            ];
+        }
+        if target_name == "test" || target_name == "lint" {
+            inputs.source_globs.extend([
+                "src/test/**/*".to_string(),
+                "src/integrationTest/**/*".to_string(),
+                "src/testFixtures/**/*".to_string(),
+            ]);
+        }
+        inputs
+    }
+}
+
+fn is_settings_file(filename: &str) -> bool {
+    filename == "settings.gradle" || filename == "settings.gradle.kts"
+}
+
+fn has_settings_file(directory: &Path) -> bool {
+    directory.join("settings.gradle").is_file() || directory.join("settings.gradle.kts").is_file()
+}
+
+fn directory_name(directory: &Path) -> Option<String> {
+    directory
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(str::to_string)
+}
+
+fn gradle_build_name(filename: &str) -> Option<String> {
+    filename
+        .strip_suffix(".gradle.kts")
+        .or_else(|| filename.strip_suffix(".gradle"))
+        .filter(|name| *name != "build")
+        .map(str::to_string)
+}
+
+fn find_gradle_root(project_dir: &Path) -> PathBuf {
+    project_dir
+        .ancestors()
+        .find(|directory| has_settings_file(directory))
+        .unwrap_or(project_dir)
+        .to_path_buf()
+}
+
+fn read_settings(build_root: &Path) -> String {
+    std::fs::read_to_string(build_root.join("settings.gradle.kts"))
+        .or_else(|_| std::fs::read_to_string(build_root.join("settings.gradle")))
+        .unwrap_or_default()
+}
+
+fn project_directory_mappings(build_root: &Path, settings: &str) -> HashMap<String, PathBuf> {
+    PROJECT_DIR
+        .captures_iter(settings)
+        .map(|captures| {
+            (
+                captures
+                    .get(1)
+                    .expect("capture exists")
+                    .as_str()
+                    .to_string(),
+                build_root.join(captures.get(2).expect("capture exists").as_str()),
+            )
+        })
+        .collect()
+}
+
+fn gradle_task_prefix(build_root: &Path, project_dir: &Path) -> String {
+    if build_root == project_dir {
+        return String::new();
+    }
+    let settings = read_settings(build_root);
+    let mappings = project_directory_mappings(build_root, &settings);
+    let canonical_project = project_dir
+        .canonicalize()
+        .unwrap_or_else(|_| project_dir.to_path_buf());
+    if let Some((project_path, _)) = mappings.into_iter().find(|(_, directory)| {
+        directory
+            .canonicalize()
+            .unwrap_or_else(|_| directory.to_path_buf())
+            == canonical_project
+    }) {
+        return project_path;
+    }
+    let relative = project_dir.strip_prefix(build_root).unwrap_or(project_dir);
+    let default_path = format!(
+        ":{}",
+        relative
+            .components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join(":")
+    );
+    let included_paths: Vec<&str> = QUOTED_PROJECT_PATH
+        .captures_iter(&settings)
+        .filter_map(|captures| captures.get(1).map(|path| path.as_str()))
+        .collect();
+    if included_paths.contains(&default_path.as_str()) {
+        return default_path;
+    }
+
+    // Some builds derive projectDir programmatically from a longer logical
+    // name (for example `:vendor-examples-api` -> `api`). Use that mapping only
+    // when the suffix match is unique; ambiguity falls back to the filesystem
+    // path and lets Gradle fail loudly.
+    let normalized_relative = normalize_gradle_path(&default_path);
+    let suffix_matches: Vec<&str> = included_paths
+        .into_iter()
+        .filter(|path| normalize_gradle_path(path).ends_with(&normalized_relative))
+        .collect();
+    if suffix_matches.len() == 1 {
+        return suffix_matches[0].to_string();
+    }
+    default_path
+}
+
+fn normalize_gradle_path(path: &str) -> String {
+    path.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn gradle_runner(build_root: &Path) -> String {
+    if cfg!(windows) && build_root.join("gradlew.bat").is_file() {
+        "gradlew.bat".to_string()
+    } else if build_root.join("gradlew").is_file() {
+        "./gradlew".to_string()
+    } else {
+        "gradle".to_string()
+    }
+}
+
+fn native_build_resource(kind: &str, workspace_root: &Path, build_root: &Path) -> String {
+    let root = build_root
+        .strip_prefix(workspace_root)
+        .unwrap_or(build_root)
+        .to_string_lossy();
+    format!("{kind}-build:{root}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context<'a>(
+        config_path: &'a Path,
+        workspace_root: &'a Path,
+        dependencies: &'a [LocalDependency],
+    ) -> TargetContext<'a> {
+        TargetContext {
+            config_path,
+            project_dir: config_path.parent().unwrap(),
+            workspace_root,
+            dependencies,
+        }
+    }
+
+    #[test]
+    fn parses_kotlin_dsl_root_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings = temp.path().join("settings.gradle.kts");
+        std::fs::write(
+            &settings,
+            r#"
+rootProject.name = "payments"
+include("api")
+"#,
+        )
+        .unwrap();
+        std::fs::create_dir_all(temp.path().join("src/main/java")).unwrap();
+
+        let metadata = GradlePlugin.parse_project(temp.path(), &settings).unwrap();
+        assert_eq!(metadata.name, "payments");
+        assert_eq!(metadata.version, None);
+        assert!(!GradlePlugin.should_skip(&settings));
+    }
+
+    #[test]
+    fn skips_pure_aggregator_and_duplicate_root_build_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let settings = temp.path().join("settings.gradle.kts");
+        let build = temp.path().join("build.gradle.kts");
+        std::fs::write(&settings, "include(\"api\")").unwrap();
+        std::fs::write(&build, "plugins { java }").unwrap();
+
+        assert!(GradlePlugin.should_skip(&settings));
+        assert!(GradlePlugin.should_skip(&build));
+    }
+
+    #[test]
+    fn recognizes_safe_custom_build_filename_but_not_auxiliary_script() {
+        let temp = tempfile::tempdir().unwrap();
+        let module = temp.path().join("api");
+        std::fs::create_dir_all(&module).unwrap();
+        let custom = module.join("api.gradle.kts");
+        let auxiliary = module.join("publishing.gradle.kts");
+        std::fs::write(&custom, "plugins { java }").unwrap();
+        std::fs::write(&auxiliary, "").unwrap();
+
+        assert!(GradlePlugin.matches_marker("api.gradle.kts"));
+        assert!(!GradlePlugin.should_skip(&custom));
+        assert!(GradlePlugin.should_skip(&auxiliary));
+    }
+
+    #[test]
+    fn defers_project_dependencies_to_gradle() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        std::fs::write(
+            root.join("settings.gradle.kts"),
+            r#"include("shared", "services:api")"#,
+        )
+        .unwrap();
+        for path in ["shared", "services/api"] {
+            std::fs::create_dir_all(root.join(path)).unwrap();
+            std::fs::write(root.join(path).join("build.gradle.kts"), "").unwrap();
+        }
+        let api_build = root.join("services/api/build.gradle.kts");
+        std::fs::write(
+            &api_build,
+            r#"
+dependencies {
+    implementation(project(":shared"))
+    testImplementation(projects.shared)
+}
+"#,
+        )
+        .unwrap();
+
+        assert!(GradlePlugin
+            .parse_dependencies(&api_build)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn scopes_wrapper_targets_to_module_and_defers_native_dependency_ordering() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::write(root.join("settings.gradle"), "include 'lib', 'app'").unwrap();
+        std::fs::write(root.join("gradlew"), "").unwrap();
+        for module in ["lib", "app"] {
+            std::fs::create_dir_all(root.join(module)).unwrap();
+            std::fs::write(
+                root.join(module).join("build.gradle"),
+                "apply plugin: 'java'",
+            )
+            .unwrap();
+        }
+        let app_build = root.join("app/build.gradle");
+        let dependencies = vec![LocalDependency {
+            name: "lib".to_string(),
+            path: root.join("lib"),
+        }];
+        let ctx = context(&app_build, &root, &dependencies);
+        let targets = GradlePlugin.detect_targets(&ctx).unwrap();
+
+        let build = &targets["build"];
+        assert_eq!(build.command, "./gradlew :app:build");
+        assert_eq!(build.working_dir.as_deref(), Some(root.as_path()));
+        assert_eq!(build.depends_on, vec!["//self:deps"]);
+        assert_eq!(build.exclusive_resources, vec!["gradle-build:"]);
+        assert_eq!(targets["clean"].command, "./gradlew :app:clean");
+        assert!(targets["clean"].invalidates_cache);
+    }
+
+    #[test]
+    fn resolves_logical_project_name_that_differs_from_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::write(
+            root.join("settings.gradle.kts"),
+            r#"include(":vendor-examples-api", ":vendor-examples-worker")"#,
+        )
+        .unwrap();
+        std::fs::write(root.join("gradlew"), "").unwrap();
+        let module = root.join("api");
+        std::fs::create_dir_all(&module).unwrap();
+        let build = module.join("build.gradle.kts");
+        std::fs::write(&build, "plugins { java }").unwrap();
+
+        let targets = GradlePlugin
+            .detect_targets(&context(&build, &root, &[]))
+            .unwrap();
+        assert_eq!(
+            targets["test"].command,
+            "./gradlew :vendor-examples-api:test"
+        );
+    }
+
+    #[test]
+    fn resolves_explicit_custom_project_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::write(
+            root.join("settings.gradle"),
+            "include ':api'\nproject(':api').projectDir = file('services/backend')\n",
+        )
+        .unwrap();
+        let module = root.join("services/backend");
+        std::fs::create_dir_all(&module).unwrap();
+        let build = module.join("build.gradle");
+        std::fs::write(&build, "apply plugin: 'java'").unwrap();
+
+        let targets = GradlePlugin
+            .detect_targets(&context(&build, &root, &[]))
+            .unwrap();
+        assert_eq!(targets["build"].command, "gradle :api:build");
+    }
+
+    #[test]
+    fn detects_format_tool_and_cache_boundaries() {
+        let temp = tempfile::tempdir().unwrap();
+        let build = temp.path().join("build.gradle.kts");
+        std::fs::write(&build, r#"plugins { id("com.diffplug.spotless") }"#).unwrap();
+        let ctx = context(&build, temp.path(), &[]);
+        let targets = GradlePlugin.detect_targets(&ctx).unwrap();
+
+        assert_eq!(targets["format"].command, "gradle spotlessApply");
+        assert!(GradlePlugin.cache_inputs("deps").source_globs.is_empty());
+        assert!(GradlePlugin
+            .cache_inputs("test")
+            .source_globs
+            .contains(&"src/test/**/*".to_string()));
+    }
+
+    #[test]
+    fn existing_non_gradle_marker_wins_colocated_address() {
+        let temp = tempfile::tempdir().unwrap();
+        let build = temp.path().join("build.gradle");
+        std::fs::write(&build, "").unwrap();
+        std::fs::write(temp.path().join("pom.xml"), "<project/>").unwrap();
+        assert!(GradlePlugin.should_skip(&build));
+    }
+}

--- a/src/plugins/jvm.rs
+++ b/src/plugins/jvm.rs
@@ -1,0 +1,78 @@
+use ignore::WalkBuilder;
+use std::path::Path;
+
+/// Detect JVM source languages from source files beneath a project's `src`
+/// directory. Build scripts such as `build.gradle.kts` intentionally do not
+/// participate: Kotlin DSL is a build configuration language, not evidence
+/// that the project itself contains Kotlin.
+pub(super) fn source_languages(project_dir: &Path) -> Vec<String> {
+    let source_root = project_dir.join("src");
+    if !source_root.is_dir() {
+        return Vec::new();
+    }
+
+    let mut java = false;
+    let mut kotlin = false;
+    for entry in WalkBuilder::new(source_root)
+        .hidden(false)
+        .git_ignore(true)
+        .git_exclude(true)
+        .git_global(true)
+        .build()
+        .filter_map(Result::ok)
+    {
+        if !entry.file_type().is_some_and(|kind| kind.is_file()) {
+            continue;
+        }
+        match entry
+            .path()
+            .extension()
+            .and_then(|extension| extension.to_str())
+        {
+            Some("java") => java = true,
+            // Kotlin scripts beneath src/ are project sources (for example,
+            // Gradle precompiled script plugins). Top-level build.gradle.kts
+            // is outside this walk and remains build-system metadata only.
+            Some("kt" | "kts") => kotlin = true,
+            _ => {}
+        }
+        if java && kotlin {
+            break;
+        }
+    }
+
+    let mut languages = Vec::new();
+    if java {
+        languages.push("java".to_string());
+    }
+    if kotlin {
+        languages.push("kotlin".to_string());
+    }
+    languages
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_jvm_sources_without_treating_build_scripts_as_project_language() {
+        let temp = tempfile::tempdir().unwrap();
+        std::fs::write(temp.path().join("build.gradle.kts"), "plugins { java }").unwrap();
+        assert!(source_languages(temp.path()).is_empty());
+
+        std::fs::create_dir_all(temp.path().join("src/test/kotlin")).unwrap();
+        std::fs::write(temp.path().join("src/test/kotlin/setup.kts"), "").unwrap();
+        assert_eq!(source_languages(temp.path()), vec!["kotlin"]);
+
+        std::fs::create_dir_all(temp.path().join("src/main/java")).unwrap();
+        std::fs::write(temp.path().join("src/main/java/App.java"), "class App {}").unwrap();
+        std::fs::write(
+            temp.path().join("src/test/kotlin/AppTest.kt"),
+            "class AppTest",
+        )
+        .unwrap();
+
+        assert_eq!(source_languages(temp.path()), vec!["java", "kotlin"]);
+    }
+}

--- a/src/plugins/maven.rs
+++ b/src/plugins/maven.rs
@@ -1,0 +1,479 @@
+//! Maven language plugin for JVM projects.
+
+use anyhow::{anyhow, Context, Result};
+use roxmltree::{Document, Node};
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use super::{
+    CacheInputs, LanguagePlugin, LocalDependency, ProjectMetadata, Target, TargetCapability,
+    TargetContext,
+};
+
+/// Plugin for Maven JVM builds.
+pub struct MavenPlugin;
+
+impl LanguagePlugin for MavenPlugin {
+    fn name(&self) -> &str {
+        "maven"
+    }
+
+    fn marker_files(&self) -> &[&str] {
+        &["pom.xml"]
+    }
+
+    fn should_skip(&self, config_path: &Path) -> bool {
+        let Some(project_dir) = config_path.parent() else {
+            return true;
+        };
+        let components: Vec<_> = config_path
+            .components()
+            .filter_map(|component| component.as_os_str().to_str())
+            .collect();
+        if components
+            .windows(2)
+            .any(|pair| pair == ["src", "it"] || pair == ["src", "test"])
+        {
+            return true;
+        }
+        let Ok(content) = std::fs::read_to_string(config_path) else {
+            return false;
+        };
+        let Ok(document) = Document::parse(&content) else {
+            return false;
+        };
+        let project = document.root_element();
+        let has_modules = child(project, "modules")
+            .is_some_and(|modules| children(modules, "module").next().is_some());
+        has_modules && !has_jvm_sources(project_dir)
+    }
+
+    fn parse_project(&self, _root: &Path, config_path: &Path) -> Result<ProjectMetadata> {
+        let content = std::fs::read_to_string(config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+        let document = Document::parse(&content)
+            .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+        let project = document.root_element();
+        let name = child_text(project, "artifactId")
+            .ok_or_else(|| anyhow!("Missing <artifactId> in {}", config_path.display()))?
+            .to_string();
+        let version = child_text(project, "version")
+            .or_else(|| child(project, "parent").and_then(|parent| child_text(parent, "version")))
+            .map(str::to_string);
+
+        Ok(ProjectMetadata { name, version })
+    }
+
+    fn parse_dependencies(&self, config_path: &Path) -> Result<Vec<LocalDependency>> {
+        // Maven's reactor owns dependency scopes, plugin dependencies, build
+        // extensions, and ordering. `-pl ... -am` preserves that exact model.
+        let _ = config_path;
+        Ok(Vec::new())
+    }
+
+    fn detect_targets(&self, ctx: &TargetContext) -> Result<HashMap<String, Target>> {
+        let reactor_root = find_maven_reactor_root(ctx.project_dir);
+        let runner = maven_runner(&reactor_root);
+        let artifact = read_maven_artifact(ctx.config_path);
+        let is_module = reactor_root != ctx.project_dir;
+        let module_args = if is_module {
+            artifact
+                .as_deref()
+                .map(|artifact| format!("-pl :{artifact}"))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+        let resource = native_build_resource("maven", ctx.workspace_root, reactor_root.as_path());
+        let working_dir = Some(reactor_root.clone());
+        // Maven's reactor owns module ordering. `-am` selects the required
+        // reactor dependencies with their actual Maven scopes; unconditional
+        // Aster build edges would duplicate work and can invent cycles.
+        let base_dependencies = vec!["//self:deps".to_string()];
+
+        let command = |goals: &str, also_make: bool| {
+            let mut parts = vec![runner.clone()];
+            if !module_args.is_empty() {
+                parts.push(module_args.clone());
+                if also_make {
+                    parts.push("-am".to_string());
+                }
+            }
+            parts.push(goals.to_string());
+            parts.join(" ")
+        };
+        let make_target = |command: String,
+                           depends_on: Vec<String>,
+                           invalidates_cache: bool,
+                           warnings_as_errors: bool| {
+            let mut capabilities = HashSet::new();
+            if warnings_as_errors {
+                capabilities.insert(TargetCapability::WarningsAsErrors);
+            }
+            Target {
+                command,
+                depends_on,
+                capabilities,
+                files_glob: None,
+                stream: false,
+                cache: None,
+                invalidates_cache,
+                working_dir: working_dir.clone(),
+                exclusive_resources: vec![resource.clone()],
+            }
+        };
+
+        let mut targets = HashMap::new();
+        targets.insert(
+            "deps".to_string(),
+            make_target(command("dependency:go-offline", true), vec![], false, false),
+        );
+        targets.insert(
+            "build".to_string(),
+            make_target(
+                command("package -DskipTests", true),
+                base_dependencies.clone(),
+                false,
+                true,
+            ),
+        );
+        targets.insert(
+            "test".to_string(),
+            make_target(
+                command("test", true),
+                base_dependencies.clone(),
+                false,
+                true,
+            ),
+        );
+        targets.insert(
+            "lint".to_string(),
+            make_target(
+                command("verify -DskipTests", true),
+                base_dependencies,
+                false,
+                true,
+            ),
+        );
+
+        let content = std::fs::read_to_string(ctx.config_path).unwrap_or_default();
+        let format_goal = if content.contains("spotless-maven-plugin") {
+            Some("spotless:apply")
+        } else if content.contains("fmt-maven-plugin") {
+            Some("fmt:format")
+        } else {
+            None
+        };
+        if let Some(format_goal) = format_goal {
+            targets.insert(
+                "format".to_string(),
+                make_target(
+                    command(format_goal, true),
+                    vec!["//self:deps".to_string()],
+                    false,
+                    false,
+                ),
+            );
+        }
+        targets.insert(
+            "clean".to_string(),
+            make_target(command("clean", false), vec![], true, false),
+        );
+        Ok(targets)
+    }
+
+    fn with_warnings_as_errors(&self, target_name: &str, command: &str) -> Option<String> {
+        matches!(target_name, "build" | "test" | "lint")
+            .then(|| format!("{command} -Dmaven.compiler.failOnWarning=true"))
+    }
+
+    fn cache_inputs(&self, target_name: &str) -> CacheInputs {
+        let mut inputs = CacheInputs {
+            source_globs: Vec::new(),
+            config_files: vec![
+                "pom.xml".to_string(),
+                ".mvn/**/*".to_string(),
+                "mvnw".to_string(),
+                "mvnw.cmd".to_string(),
+            ],
+            env_vars: vec![
+                "JAVA_HOME".to_string(),
+                "MAVEN_OPTS".to_string(),
+                "MAVEN_ARGS".to_string(),
+                "CI".to_string(),
+            ],
+        };
+        if target_name != "deps" {
+            inputs.source_globs = vec![
+                "src/**/*.java".to_string(),
+                "src/**/*.kt".to_string(),
+                "src/**/*.kts".to_string(),
+                "src/**/*.groovy".to_string(),
+                "src/**/*.scala".to_string(),
+                "src/main/resources/**/*".to_string(),
+            ];
+        }
+        if target_name == "test" || target_name == "lint" {
+            inputs
+                .source_globs
+                .extend(["src/test/**/*".to_string(), "src/it/**/*".to_string()]);
+        }
+        inputs
+    }
+}
+
+fn child<'a>(node: Node<'a, 'a>, name: &str) -> Option<Node<'a, 'a>> {
+    node.children()
+        .find(|child| child.is_element() && child.tag_name().name() == name)
+}
+
+fn children<'a>(node: Node<'a, 'a>, name: &'a str) -> impl Iterator<Item = Node<'a, 'a>> + 'a {
+    node.children()
+        .filter(move |child| child.is_element() && child.tag_name().name() == name)
+}
+
+fn child_text<'a>(node: Node<'a, 'a>, name: &str) -> Option<&'a str> {
+    child(node, name)?
+        .text()
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+}
+
+fn has_jvm_sources(project_dir: &Path) -> bool {
+    ["java", "kotlin", "groovy", "scala"]
+        .iter()
+        .any(|language| project_dir.join("src/main").join(language).is_dir())
+}
+
+fn read_maven_artifact(config_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(config_path).ok()?;
+    let document = Document::parse(&content).ok()?;
+    child_text(document.root_element(), "artifactId").map(str::to_string)
+}
+
+fn pom_modules(pom_path: &Path) -> Vec<PathBuf> {
+    let Ok(content) = std::fs::read_to_string(pom_path) else {
+        return Vec::new();
+    };
+    let Ok(document) = Document::parse(&content) else {
+        return Vec::new();
+    };
+    child(document.root_element(), "modules")
+        .map(|modules| {
+            children(modules, "module")
+                .filter_map(|module| module.text())
+                .map(str::trim)
+                .filter(|module| !module.is_empty())
+                .map(PathBuf::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn find_maven_reactor_root(project_dir: &Path) -> PathBuf {
+    let canonical_project = project_dir
+        .canonicalize()
+        .unwrap_or_else(|_| project_dir.to_path_buf());
+    let mut reactor_root = project_dir.to_path_buf();
+
+    for ancestor in project_dir.ancestors().skip(1) {
+        let pom = ancestor.join("pom.xml");
+        if !pom.is_file() {
+            continue;
+        }
+        let contains_project = pom_modules(&pom).into_iter().any(|module| {
+            let module_dir = ancestor.join(module);
+            let canonical_module = module_dir.canonicalize().unwrap_or(module_dir);
+            canonical_project.starts_with(canonical_module)
+        });
+        if contains_project {
+            reactor_root = ancestor.to_path_buf();
+        }
+    }
+    reactor_root
+}
+
+fn maven_runner(reactor_root: &Path) -> String {
+    if cfg!(windows) && reactor_root.join("mvnw.cmd").is_file() {
+        "mvnw.cmd".to_string()
+    } else if reactor_root.join("mvnw").is_file() {
+        "./mvnw".to_string()
+    } else {
+        "mvn".to_string()
+    }
+}
+
+fn native_build_resource(kind: &str, workspace_root: &Path, build_root: &Path) -> String {
+    let root = build_root
+        .strip_prefix(workspace_root)
+        .unwrap_or(build_root)
+        .to_string_lossy();
+    format!("{kind}-build:{root}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context<'a>(
+        config_path: &'a Path,
+        workspace_root: &'a Path,
+        dependencies: &'a [LocalDependency],
+    ) -> TargetContext<'a> {
+        TargetContext {
+            config_path,
+            project_dir: config_path.parent().unwrap(),
+            workspace_root,
+            dependencies,
+        }
+    }
+
+    #[test]
+    fn parses_namespaced_pom_and_inherited_version() {
+        let temp = tempfile::tempdir().unwrap();
+        let pom = temp.path().join("pom.xml");
+        std::fs::write(
+            &pom,
+            r#"<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <parent>
+    <groupId>dev.example</groupId>
+    <artifactId>parent</artifactId>
+    <version>2.1.0</version>
+  </parent>
+  <artifactId>api</artifactId>
+</project>"#,
+        )
+        .unwrap();
+
+        let metadata = MavenPlugin.parse_project(temp.path(), &pom).unwrap();
+        assert_eq!(metadata.name, "api");
+        assert_eq!(metadata.version.as_deref(), Some("2.1.0"));
+    }
+
+    #[test]
+    fn defers_reactor_dependencies_to_maven() {
+        let temp = tempfile::tempdir().unwrap();
+        let pom = temp.path().join("pom.xml");
+        std::fs::write(
+            &pom,
+            r#"<project>
+  <artifactId>app</artifactId>
+  <dependencyManagement><dependencies><dependency>
+    <artifactId>managed</artifactId>
+  </dependency></dependencies></dependencyManagement>
+  <dependencies>
+    <dependency><groupId>dev.example</groupId><artifactId>shared</artifactId></dependency>
+  </dependencies>
+</project>"#,
+        )
+        .unwrap();
+
+        assert!(MavenPlugin.parse_dependencies(&pom).unwrap().is_empty());
+    }
+
+    #[test]
+    fn skips_pure_aggregator_but_keeps_source_bearing_parent() {
+        let temp = tempfile::tempdir().unwrap();
+        let pom = temp.path().join("pom.xml");
+        std::fs::write(
+            &pom,
+            "<project><artifactId>root</artifactId><packaging>pom</packaging><modules><module>api</module></modules></project>",
+        )
+        .unwrap();
+        assert!(MavenPlugin.should_skip(&pom));
+
+        std::fs::create_dir_all(temp.path().join("src/main/java")).unwrap();
+        assert!(!MavenPlugin.should_skip(&pom));
+    }
+
+    #[test]
+    fn skips_embedded_maven_test_fixture() {
+        let temp = tempfile::tempdir().unwrap();
+        let fixture = temp.path().join("src/it/sample/pom.xml");
+        std::fs::create_dir_all(fixture.parent().unwrap()).unwrap();
+        std::fs::write(
+            &fixture,
+            "<project><artifactId>fixture</artifactId></project>",
+        )
+        .unwrap();
+        assert!(MavenPlugin.should_skip(&fixture));
+    }
+
+    #[test]
+    fn scopes_wrapper_targets_to_reactor_module() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().canonicalize().unwrap();
+        std::fs::write(
+            root.join("pom.xml"),
+            "<project><artifactId>root</artifactId><modules><module>api</module></modules></project>",
+        )
+        .unwrap();
+        std::fs::write(root.join("mvnw"), "").unwrap();
+        let module = root.join("api");
+        std::fs::create_dir_all(module.join("src/main/java")).unwrap();
+        let pom = module.join("pom.xml");
+        std::fs::write(&pom, "<project><artifactId>api</artifactId></project>").unwrap();
+        let dependencies = vec![LocalDependency {
+            name: "shared".to_string(),
+            path: PathBuf::from("//shared"),
+        }];
+        let ctx = context(&pom, &root, &dependencies);
+        let targets = MavenPlugin.detect_targets(&ctx).unwrap();
+
+        assert_eq!(
+            targets["build"].command,
+            "./mvnw -pl :api -am package -DskipTests"
+        );
+        assert_eq!(targets["test"].command, "./mvnw -pl :api -am test");
+        assert_eq!(targets["clean"].command, "./mvnw -pl :api clean");
+        assert_eq!(
+            targets["build"].working_dir.as_deref(),
+            Some(root.as_path())
+        );
+        assert_eq!(targets["build"].depends_on, vec!["//self:deps"]);
+        assert_eq!(targets["build"].exclusive_resources, vec!["maven-build:"]);
+    }
+
+    #[test]
+    fn standalone_project_uses_system_maven() {
+        let temp = tempfile::tempdir().unwrap();
+        let pom = temp.path().join("pom.xml");
+        std::fs::write(&pom, "<project><artifactId>api</artifactId></project>").unwrap();
+        let targets = MavenPlugin
+            .detect_targets(&context(&pom, temp.path(), &[]))
+            .unwrap();
+        assert_eq!(targets["build"].command, "mvn package -DskipTests");
+    }
+
+    #[test]
+    fn detects_spotless_and_warnings_as_errors() {
+        let temp = tempfile::tempdir().unwrap();
+        let pom = temp.path().join("pom.xml");
+        std::fs::write(
+            &pom,
+            "<project><artifactId>api</artifactId><build><plugins><plugin><artifactId>spotless-maven-plugin</artifactId></plugin></plugins></build></project>",
+        )
+        .unwrap();
+        let targets = MavenPlugin
+            .detect_targets(&context(&pom, temp.path(), &[]))
+            .unwrap();
+        assert_eq!(targets["format"].command, "mvn spotless:apply");
+        assert_eq!(
+            MavenPlugin.with_warnings_as_errors("build", &targets["build"].command),
+            Some("mvn package -DskipTests -Dmaven.compiler.failOnWarning=true".to_string())
+        );
+        assert_eq!(
+            MavenPlugin.with_warnings_as_errors("clean", "mvn clean"),
+            None
+        );
+    }
+
+    #[test]
+    fn dependency_cache_excludes_sources() {
+        assert!(MavenPlugin.cache_inputs("deps").source_globs.is_empty());
+        assert!(MavenPlugin
+            .cache_inputs("test")
+            .source_globs
+            .contains(&"src/test/**/*".to_string()));
+    }
+}

--- a/src/plugins/maven.rs
+++ b/src/plugins/maven.rs
@@ -5,6 +5,7 @@ use roxmltree::{Document, Node};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
+use super::jvm;
 use super::{
     CacheInputs, LanguagePlugin, LocalDependency, ProjectMetadata, Target, TargetCapability,
     TargetContext,
@@ -16,6 +17,27 @@ pub struct MavenPlugin;
 impl LanguagePlugin for MavenPlugin {
     fn name(&self) -> &str {
         "maven"
+    }
+
+    fn languages(&self, project_dir: &Path, config_path: &Path) -> Result<Vec<String>> {
+        let mut languages = jvm::source_languages(project_dir);
+        let content = std::fs::read_to_string(config_path).unwrap_or_default();
+        let has_kotlin_plugin = content.contains("kotlin-maven-plugin");
+
+        if has_kotlin_plugin && !languages.iter().any(|language| language == "kotlin") {
+            languages.push("kotlin".to_string());
+        }
+        // Java is Maven's default source language when no Kotlin evidence is
+        // present. This also gives empty starter projects a useful language.
+        if languages.is_empty() {
+            languages.push(if has_kotlin_plugin { "kotlin" } else { "java" }.to_string());
+        }
+        languages.sort();
+        Ok(languages)
+    }
+
+    fn build_system(&self) -> Option<&str> {
+        Some("maven")
     }
 
     fn marker_files(&self) -> &[&str] {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -93,8 +93,24 @@ pub struct TargetContext<'a> {
 
 /// Trait that each language plugin implements
 pub trait LanguagePlugin: Send + Sync {
-    /// Plugin identifier (e.g., "nodejs", "elixir")
+    /// Internal plugin identifier (e.g., "nodejs", "gradle", "maven")
     fn name(&self) -> &str;
+
+    /// Languages used by the discovered project.
+    ///
+    /// Most plugins represent one language, so their plugin identifier is the
+    /// language name. Build-system plugins can override this to detect one or
+    /// more source languages independently from the backend used to execute
+    /// targets.
+    fn languages(&self, _project_dir: &Path, _config_path: &Path) -> Result<Vec<String>> {
+        Ok(vec![self.name().to_string()])
+    }
+
+    /// Build system used to execute this project's targets, when distinct
+    /// from its language identity.
+    fn build_system(&self) -> Option<&str> {
+        None
+    }
 
     /// Files that identify this project type (e.g., ["package.json"])
     fn marker_files(&self) -> &[&str];
@@ -208,6 +224,7 @@ pub trait LanguagePlugin: Send + Sync {
 pub mod elixir;
 pub mod go;
 pub mod gradle;
+mod jvm;
 pub mod maven;
 pub mod nodejs;
 pub mod python;

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -212,6 +212,7 @@ pub mod maven;
 pub mod nodejs;
 pub mod python;
 pub mod registry;
+pub mod ruby;
 pub mod rust;
 
 pub use elixir::ElixirPlugin;
@@ -221,6 +222,7 @@ pub use maven::MavenPlugin;
 pub use nodejs::NodeJsPlugin;
 pub use python::PythonPlugin;
 pub use registry::PluginRegistry;
+pub use ruby::RubyPlugin;
 pub use rust::RustPlugin;
 
 // Re-export CacheInputs for use by cache module

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -99,6 +99,15 @@ pub trait LanguagePlugin: Send + Sync {
     /// Files that identify this project type (e.g., ["package.json"])
     fn marker_files(&self) -> &[&str];
 
+    /// Whether this plugin recognizes a marker filename.
+    ///
+    /// Most plugins use exact marker filenames. Build systems such as Gradle
+    /// may also use project-specific build filenames, so they can override
+    /// this method and let `should_skip` apply the path-aware filtering.
+    fn matches_marker(&self, filename: &str) -> bool {
+        self.marker_files().contains(&filename)
+    }
+
     /// Check if this config file should be skipped during discovery
     ///
     /// Some marker files don't represent buildable projects. For example,
@@ -198,6 +207,8 @@ pub trait LanguagePlugin: Send + Sync {
 
 pub mod elixir;
 pub mod go;
+pub mod gradle;
+pub mod maven;
 pub mod nodejs;
 pub mod python;
 pub mod registry;
@@ -205,6 +216,8 @@ pub mod rust;
 
 pub use elixir::ElixirPlugin;
 pub use go::GoPlugin;
+pub use gradle::GradlePlugin;
+pub use maven::MavenPlugin;
 pub use nodejs::NodeJsPlugin;
 pub use python::PythonPlugin;
 pub use registry::PluginRegistry;

--- a/src/plugins/nodejs.rs
+++ b/src/plugins/nodejs.rs
@@ -163,6 +163,27 @@ impl LanguagePlugin for NodeJsPlugin {
         &["package.json"]
     }
 
+    fn should_skip(&self, config_path: &Path) -> bool {
+        let Some(project_dir) = config_path.parent() else {
+            return false;
+        };
+        // Rails applications and packaged gems often colocate JavaScript
+        // assets with their primary Ruby project. Aster addresses are
+        // directory-based, so prefer the Ruby build when a gemspec or Rails
+        // executable makes that ownership unambiguous.
+        (project_dir.join("Gemfile").is_file() && project_dir.join("bin/rails").is_file())
+            || std::fs::read_dir(project_dir)
+                .into_iter()
+                .flatten()
+                .filter_map(Result::ok)
+                .any(|entry| {
+                    entry
+                        .path()
+                        .extension()
+                        .is_some_and(|extension| extension == "gemspec")
+                })
+    }
+
     fn parse_project(&self, _root: &Path, config_path: &Path) -> Result<ProjectMetadata> {
         let content = std::fs::read_to_string(config_path)
             .with_context(|| format!("Failed to read {}", config_path.display()))?;
@@ -2353,5 +2374,15 @@ mod tests {
             "consumer:build should depend on //packages/dep:build; got {:?}",
             build.depends_on
         );
+    }
+
+    #[test]
+    fn packaged_ruby_project_owns_colocated_javascript_assets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let package = tmp.path().join("package.json");
+        std::fs::write(&package, r#"{"name":"assets"}"#).unwrap();
+        std::fs::write(tmp.path().join("app.gemspec"), "s.name = 'app'\n").unwrap();
+
+        assert!(NodeJsPlugin.should_skip(&package));
     }
 }

--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -1,6 +1,6 @@
 use super::{
     ElixirPlugin, GoPlugin, GradlePlugin, LanguagePlugin, MavenPlugin, NodeJsPlugin, PythonPlugin,
-    RustPlugin,
+    RubyPlugin, RustPlugin,
 };
 
 /// Registry of available language plugins
@@ -25,6 +25,7 @@ impl PluginRegistry {
         registry.register(Box::new(RustPlugin));
         registry.register(Box::new(GradlePlugin));
         registry.register(Box::new(MavenPlugin));
+        registry.register(Box::new(RubyPlugin));
         registry
     }
 
@@ -189,13 +190,18 @@ mod tests {
     }
 
     #[test]
-    fn all_builtin_plugins_include_jvm_build_systems() {
+    fn all_builtin_plugins_are_registered() {
         let registry = PluginRegistry::with_all_plugins();
-        assert_eq!(registry.plugins().len(), 7);
+        assert_eq!(registry.plugins().len(), 8);
         assert_eq!(registry.find_by_marker("pom.xml").unwrap().name(), "maven");
         assert_eq!(
             registry.find_by_marker("build.gradle.kts").unwrap().name(),
             "gradle"
+        );
+        assert_eq!(registry.find_by_marker("Gemfile").unwrap().name(), "ruby");
+        assert_eq!(
+            registry.find_by_marker("sample.gemspec").unwrap().name(),
+            "ruby"
         );
         assert_eq!(
             registry

--- a/src/plugins/registry.rs
+++ b/src/plugins/registry.rs
@@ -1,4 +1,7 @@
-use super::{ElixirPlugin, GoPlugin, LanguagePlugin, NodeJsPlugin, PythonPlugin, RustPlugin};
+use super::{
+    ElixirPlugin, GoPlugin, GradlePlugin, LanguagePlugin, MavenPlugin, NodeJsPlugin, PythonPlugin,
+    RustPlugin,
+};
 
 /// Registry of available language plugins
 pub struct PluginRegistry {
@@ -20,6 +23,8 @@ impl PluginRegistry {
         registry.register(Box::new(PythonPlugin));
         registry.register(Box::new(GoPlugin));
         registry.register(Box::new(RustPlugin));
+        registry.register(Box::new(GradlePlugin));
+        registry.register(Box::new(MavenPlugin));
         registry
     }
 
@@ -37,7 +42,7 @@ impl PluginRegistry {
     pub fn find_by_marker(&self, filename: &str) -> Option<&dyn LanguagePlugin> {
         self.plugins
             .iter()
-            .find(|p| p.marker_files().contains(&filename))
+            .find(|p| p.matches_marker(filename))
             .map(|p| p.as_ref())
     }
 
@@ -181,5 +186,23 @@ mod tests {
         // Unknown name returns None
         assert!(registry.find_by_name("unknown").is_none());
         assert!(registry.find_by_name("").is_none());
+    }
+
+    #[test]
+    fn all_builtin_plugins_include_jvm_build_systems() {
+        let registry = PluginRegistry::with_all_plugins();
+        assert_eq!(registry.plugins().len(), 7);
+        assert_eq!(registry.find_by_marker("pom.xml").unwrap().name(), "maven");
+        assert_eq!(
+            registry.find_by_marker("build.gradle.kts").unwrap().name(),
+            "gradle"
+        );
+        assert_eq!(
+            registry
+                .find_by_marker("custom-project.gradle.kts")
+                .unwrap()
+                .name(),
+            "gradle"
+        );
     }
 }

--- a/src/plugins/ruby.rs
+++ b/src/plugins/ruby.rs
@@ -1,0 +1,701 @@
+//! Ruby language plugin for Bundler, RubyGems, Rake, RSpec, and Rails projects.
+
+use anyhow::{Context, Result};
+use regex::Regex;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+use super::{
+    CacheInputs, LanguagePlugin, LocalDependency, ProjectMetadata, Target, TargetCapability,
+    TargetContext,
+};
+
+static GEM_NAME: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?m)^\s*[A-Za-z_]\w*\.name\s*=\s*[\"']([^\"']+)[\"']"#)
+        .expect("valid gem name regex")
+});
+static GEM_VERSION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?m)^\s*[A-Za-z_]\w*\.version\s*=\s*[\"']([^\"']+)[\"']"#)
+        .expect("valid gem version regex")
+});
+static GEMSPEC_DEPENDENCY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?m)^\s*[A-Za-z_]\w*\.add_(?:runtime_)?dependency\s*(?:\(\s*)?[\"']([^\"']+)[\"']"#,
+    )
+    .expect("valid gemspec dependency regex")
+});
+static GEMFILE_PATH_DEPENDENCY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?m)^\s*gem\s*(?:\(\s*)?[\"']([^\"']+)[\"'][^\n#]*(?:\bpath:\s*|:path\s*=>\s*)[\"']([^\"']+)[\"']"#,
+    )
+    .expect("valid Gemfile path dependency regex")
+});
+
+/// Ruby plugin for Bundler projects and packaged gems.
+pub struct RubyPlugin;
+
+impl LanguagePlugin for RubyPlugin {
+    fn name(&self) -> &str {
+        "ruby"
+    }
+
+    fn marker_files(&self) -> &[&str] {
+        &["Gemfile"]
+    }
+
+    fn matches_marker(&self, filename: &str) -> bool {
+        filename == "Gemfile" || filename.ends_with(".gemspec")
+    }
+
+    fn should_skip(&self, config_path: &Path) -> bool {
+        if is_fixture_gemspec(config_path) {
+            return true;
+        }
+
+        let Some(project_dir) = config_path.parent() else {
+            return true;
+        };
+        let is_gemfile = config_path
+            .file_name()
+            .is_some_and(|name| name == "Gemfile");
+        let gemspecs = gemspecs_in(project_dir);
+
+        // A gem's specification contains better metadata than its colocated
+        // Gemfile. Use exactly one marker so discovery cannot produce two
+        // projects with the same Aster address.
+        if is_gemfile {
+            return !gemspecs.is_empty();
+        }
+
+        gemspecs
+            .first()
+            .is_some_and(|canonical| canonical != config_path)
+    }
+
+    fn parse_project(&self, _root: &Path, config_path: &Path) -> Result<ProjectMetadata> {
+        let content = std::fs::read_to_string(config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+        let is_gemspec = config_path.extension().is_some_and(|ext| ext == "gemspec");
+
+        let name = if is_gemspec {
+            GEM_NAME
+                .captures(&content)
+                .and_then(|captures| captures.get(1))
+                .map(|value| value.as_str().to_string())
+                .or_else(|| {
+                    config_path
+                        .file_stem()
+                        .map(|stem| stem.to_string_lossy().into_owned())
+                })
+        } else {
+            config_path
+                .parent()
+                .and_then(Path::file_name)
+                .map(|name| name.to_string_lossy().into_owned())
+        }
+        .unwrap_or_else(|| "ruby-project".to_string());
+
+        let version = GEM_VERSION
+            .captures(&content)
+            .and_then(|captures| captures.get(1))
+            .map(|value| value.as_str().to_string());
+
+        Ok(ProjectMetadata { name, version })
+    }
+
+    fn parse_dependencies(&self, config_path: &Path) -> Result<Vec<LocalDependency>> {
+        let mut dependencies = Vec::new();
+        let config_content = std::fs::read_to_string(config_path)
+            .with_context(|| format!("Failed to read {}", config_path.display()))?;
+
+        if config_path.extension().is_some_and(|ext| ext == "gemspec") {
+            for captures in GEMSPEC_DEPENDENCY.captures_iter(&config_content) {
+                let name = captures[1].to_string();
+                dependencies.push(LocalDependency {
+                    path: PathBuf::from(format!("ruby_workspace:{name}")),
+                    name,
+                });
+            }
+        }
+
+        let project_dir = config_path.parent().unwrap_or_else(|| Path::new("."));
+        let gemfile = project_dir.join("Gemfile");
+        let gemfile_content = if config_path
+            .file_name()
+            .is_some_and(|name| name == "Gemfile")
+        {
+            Some(config_content.clone())
+        } else {
+            std::fs::read_to_string(&gemfile).ok()
+        };
+
+        if let Some(content) = gemfile_content.as_deref() {
+            for captures in GEMFILE_PATH_DEPENDENCY.captures_iter(content) {
+                dependencies.push(LocalDependency {
+                    name: captures[1].to_string(),
+                    path: PathBuf::from(&captures[2]),
+                });
+            }
+        }
+
+        dependencies
+            .sort_by(|left, right| left.name.cmp(&right.name).then(left.path.cmp(&right.path)));
+        dependencies.dedup_by(|left, right| left.name == right.name && left.path == right.path);
+        Ok(dependencies)
+    }
+
+    fn detect_targets(&self, ctx: &TargetContext) -> Result<HashMap<String, Target>> {
+        let project_content = project_content(ctx.project_dir, ctx.config_path)?;
+        let rakefile =
+            std::fs::read_to_string(ctx.project_dir.join("Rakefile")).unwrap_or_default();
+        let bundle_root = nearest_gemfile(ctx.project_dir, ctx.workspace_root)
+            .and_then(|gemfile| gemfile.parent().map(Path::to_path_buf));
+        let uses_bundler = bundle_root.is_some();
+        let uses_ancestor_gemfile = bundle_root
+            .as_deref()
+            .is_some_and(|root| root != ctx.project_dir);
+        let mut targets = HashMap::new();
+
+        if uses_bundler {
+            targets.insert(
+                "deps".to_string(),
+                target(
+                    "bundle install",
+                    Vec::new(),
+                    HashSet::new(),
+                    bundle_root,
+                    vec!["bundler_install".to_string()],
+                ),
+            );
+        }
+
+        let base_dependencies = if uses_bundler {
+            vec!["//self:deps".to_string()]
+        } else {
+            Vec::new()
+        };
+        let exec = if uses_bundler { "bundle exec " } else { "" };
+        let is_gemspec = ctx
+            .config_path
+            .extension()
+            .is_some_and(|extension| extension == "gemspec");
+        if is_gemspec {
+            let mut capabilities = HashSet::new();
+            capabilities.insert(TargetCapability::WarningsAsErrors);
+            let filename = ctx
+                .config_path
+                .file_name()
+                .map(|name| crate::executor::quote_command_argument(&name.to_string_lossy()))
+                .unwrap_or_else(|| "*.gemspec".to_string());
+            targets.insert(
+                "build".to_string(),
+                target(
+                    &format!("{exec}gem build {filename}"),
+                    base_dependencies.clone(),
+                    capabilities,
+                    None,
+                    Vec::new(),
+                ),
+            );
+        }
+
+        let test_dir = ctx.project_dir.join("test").is_dir();
+        let spec_dir = ctx.project_dir.join("spec").is_dir();
+        let rails_executable = ctx.project_dir.join("bin/rails").is_file();
+        let (test_command, test_accepts_files) = if rails_executable && test_dir {
+            (Some("bin/rails test".to_string()), true)
+        } else if spec_dir
+            && (ctx.project_dir.join(".rspec").exists()
+                || project_content.contains("rspec")
+                || rakefile.contains("RSpec::Core::RakeTask"))
+        {
+            (Some(format!("{exec}rspec")), true)
+        } else if test_dir && rake_has_task(&rakefile, "test") {
+            (Some(format!("{exec}rake test")), false)
+        } else {
+            (None, false)
+        };
+
+        if let Some(command) = test_command {
+            let mut capabilities = HashSet::new();
+            if test_accepts_files {
+                capabilities.insert(TargetCapability::FilesList);
+            }
+            targets.insert(
+                "test".to_string(),
+                target(
+                    &command,
+                    base_dependencies.clone(),
+                    capabilities,
+                    None,
+                    Vec::new(),
+                ),
+            );
+        }
+
+        let has_rubocop =
+            ctx.project_dir.join(".rubocop.yml").exists() || project_content.contains("rubocop");
+        if has_rubocop {
+            let capabilities = HashSet::from([TargetCapability::FilesList]);
+            targets.insert(
+                "lint".to_string(),
+                target(
+                    &format!("{exec}rubocop"),
+                    base_dependencies.clone(),
+                    capabilities.clone(),
+                    None,
+                    Vec::new(),
+                ),
+            );
+            targets.insert(
+                "format".to_string(),
+                target(
+                    &format!("{exec}rubocop -A"),
+                    base_dependencies.clone(),
+                    capabilities,
+                    None,
+                    Vec::new(),
+                ),
+            );
+        }
+
+        if rails_executable {
+            targets.insert(
+                "dev".to_string(),
+                Target {
+                    stream: true,
+                    ..target(
+                        "bin/rails server",
+                        base_dependencies,
+                        HashSet::new(),
+                        None,
+                        Vec::new(),
+                    )
+                },
+            );
+        }
+
+        if let Some(clean) = self.clean_target(ctx) {
+            targets.insert("clean".to_string(), clean);
+        }
+
+        // Cache inputs are owned relative to the discovered project. A member
+        // gem cannot safely hash a Gemfile.lock above its root, so favor
+        // correctness and rerun its targets when Bundler is owned by an
+        // ancestor project.
+        if uses_ancestor_gemfile {
+            for target in targets.values_mut() {
+                target.cache = Some(crate::config::CacheConfig {
+                    enabled: Some(false),
+                    ..crate::config::CacheConfig::default()
+                });
+            }
+        }
+
+        Ok(targets)
+    }
+
+    fn with_files_list(
+        &self,
+        target_name: &str,
+        command: &str,
+        files: &[PathBuf],
+    ) -> Option<String> {
+        let matching = files
+            .iter()
+            .filter(|path| match target_name {
+                "test" => is_ruby_test(path),
+                "lint" | "format" => is_ruby_source(path),
+                _ => false,
+            })
+            .map(|path| crate::executor::quote_command_argument(&path.to_string_lossy()))
+            .collect::<Vec<_>>();
+
+        if matching.is_empty() {
+            None
+        } else {
+            Some(format!("{command} {}", matching.join(" ")))
+        }
+    }
+
+    fn with_warnings_as_errors(&self, target_name: &str, command: &str) -> Option<String> {
+        (target_name == "build").then(|| format!("{command} --strict"))
+    }
+
+    fn cache_inputs(&self, target_name: &str) -> CacheInputs {
+        if target_name == "deps" {
+            return CacheInputs {
+                source_globs: Vec::new(),
+                config_files: vec![
+                    "Gemfile".to_string(),
+                    "Gemfile.lock".to_string(),
+                    "*.gemspec".to_string(),
+                    ".ruby-version".to_string(),
+                    ".tool-versions".to_string(),
+                    ".bundle/config".to_string(),
+                ],
+                env_vars: vec![
+                    "BUNDLE_GEMFILE".to_string(),
+                    "BUNDLE_WITH".to_string(),
+                    "BUNDLE_WITHOUT".to_string(),
+                ],
+            };
+        }
+
+        let mut source_globs = vec![
+            "**/*.rb".to_string(),
+            "**/*.rake".to_string(),
+            "Rakefile".to_string(),
+            "Gemfile".to_string(),
+            "*.gemspec".to_string(),
+        ];
+        if target_name == "test" {
+            source_globs.push("test/**/*".to_string());
+            source_globs.push("spec/**/*".to_string());
+        }
+        CacheInputs {
+            source_globs,
+            config_files: vec![
+                "Gemfile.lock".to_string(),
+                ".ruby-version".to_string(),
+                ".tool-versions".to_string(),
+                ".rubocop.yml".to_string(),
+            ],
+            env_vars: vec![
+                "RUBYOPT".to_string(),
+                "RUBYLIB".to_string(),
+                "BUNDLE_GEMFILE".to_string(),
+                "RAILS_ENV".to_string(),
+                "RACK_ENV".to_string(),
+                "CI".to_string(),
+            ],
+        }
+    }
+
+    fn clean_target(&self, ctx: &TargetContext) -> Option<Target> {
+        let rakefile = std::fs::read_to_string(ctx.project_dir.join("Rakefile")).ok()?;
+        let task_name = if rake_has_task(&rakefile, "clobber") {
+            "clobber"
+        } else if rake_has_task(&rakefile, "clean") {
+            "clean"
+        } else {
+            return None;
+        };
+        Some(Target {
+            invalidates_cache: true,
+            ..target(
+                &format!(
+                    "{}rake {task_name}",
+                    if nearest_gemfile(ctx.project_dir, ctx.workspace_root).is_some() {
+                        "bundle exec "
+                    } else {
+                        ""
+                    }
+                ),
+                Vec::new(),
+                HashSet::new(),
+                None,
+                Vec::new(),
+            )
+        })
+    }
+}
+
+fn target(
+    command: &str,
+    depends_on: Vec<String>,
+    capabilities: HashSet<TargetCapability>,
+    working_dir: Option<PathBuf>,
+    exclusive_resources: Vec<String>,
+) -> Target {
+    Target {
+        command: command.to_string(),
+        depends_on,
+        capabilities,
+        files_glob: None,
+        stream: false,
+        cache: None,
+        invalidates_cache: false,
+        working_dir,
+        exclusive_resources,
+    }
+}
+
+fn gemspecs_in(directory: &Path) -> Vec<PathBuf> {
+    let mut gemspecs = std::fs::read_dir(directory)
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|extension| extension == "gemspec")
+        })
+        .collect::<Vec<_>>();
+    gemspecs.sort();
+    gemspecs
+}
+
+fn is_fixture_gemspec(path: &Path) -> bool {
+    let components = path
+        .components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>();
+    components.windows(2).any(|pair| {
+        matches!(pair[0].as_ref(), "test" | "spec" | "features")
+            && matches!(pair[1].as_ref(), "fixture" | "fixtures" | "support")
+    })
+}
+
+fn nearest_gemfile(project_dir: &Path, workspace_root: &Path) -> Option<PathBuf> {
+    let mut directory = project_dir;
+    loop {
+        let candidate = directory.join("Gemfile");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if directory == workspace_root {
+            return None;
+        }
+        directory = directory.parent()?;
+    }
+}
+
+fn project_content(project_dir: &Path, config_path: &Path) -> Result<String> {
+    let mut content = std::fs::read_to_string(config_path)
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    for filename in ["Gemfile", "Gemfile.lock", "Rakefile"] {
+        let path = project_dir.join(filename);
+        if path != config_path {
+            if let Ok(extra) = std::fs::read_to_string(path) {
+                content.push('\n');
+                content.push_str(&extra);
+            }
+        }
+    }
+    Ok(content)
+}
+
+fn rake_has_task(rakefile: &str, name: &str) -> bool {
+    if name == "test" && rakefile.contains("Rake::TestTask.new") {
+        return true;
+    }
+    let escaped = regex::escape(name);
+    Regex::new(&format!(
+        r#"(?m)^\s*task\s*(?:\(\s*)?(?::{}\b|[\"']{}[\"'])"#,
+        escaped, escaped
+    ))
+    .expect("escaped task regex is valid")
+    .is_match(rakefile)
+}
+
+fn is_ruby_test(path: &Path) -> bool {
+    let value = path.to_string_lossy();
+    let filename = path.file_name().map(|name| name.to_string_lossy());
+    value.contains("/test/")
+        || value.starts_with("test/")
+        || value.contains("/spec/")
+        || value.starts_with("spec/")
+        || filename.as_deref().is_some_and(|name| {
+            name.ends_with("_test.rb") || name.starts_with("test_") || name.ends_with("_spec.rb")
+        })
+}
+
+fn is_ruby_source(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| {
+        matches!(
+            extension.to_string_lossy().as_ref(),
+            "rb" | "rake" | "gemspec"
+        )
+    }) || path
+        .file_name()
+        .is_some_and(|name| matches!(name.to_string_lossy().as_ref(), "Gemfile" | "Rakefile"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn context<'a>(config_path: &'a Path, root: &'a Path) -> TargetContext<'a> {
+        TargetContext {
+            config_path,
+            project_dir: config_path.parent().unwrap(),
+            workspace_root: root,
+            dependencies: &[],
+        }
+    }
+
+    #[test]
+    fn gemspec_is_canonical_and_parses_literal_metadata() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemfile = tmp.path().join("Gemfile");
+        let gemspec = tmp.path().join("sample.gemspec");
+        std::fs::write(&gemfile, "gemspec\n").unwrap();
+        std::fs::write(
+            &gemspec,
+            "Gem::Specification.new do |spec|\n  spec.name = 'sample'\n  spec.version = \"1.2.3\"\nend\n",
+        )
+        .unwrap();
+
+        let plugin = RubyPlugin;
+        assert!(plugin.should_skip(&gemfile));
+        assert!(!plugin.should_skip(&gemspec));
+        let metadata = plugin.parse_project(tmp.path(), &gemspec).unwrap();
+        assert_eq!(metadata.name, "sample");
+        assert_eq!(metadata.version.as_deref(), Some("1.2.3"));
+    }
+
+    #[test]
+    fn parses_literal_path_and_workspace_dependencies_without_evaluating_ruby() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemspec = tmp.path().join("app.gemspec");
+        std::fs::write(
+            &gemspec,
+            "s.add_dependency 'shared', '~> 1.0'\ns.add_development_dependency 'rspec'\n",
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("Gemfile"),
+            "gem \"tools\", :path => \"../tools\"\ngem 'api', path: '../api'\n",
+        )
+        .unwrap();
+
+        let dependencies = RubyPlugin.parse_dependencies(&gemspec).unwrap();
+        assert_eq!(dependencies.len(), 3);
+        assert!(dependencies.iter().any(|dependency| {
+            dependency.name == "shared" && dependency.path == Path::new("ruby_workspace:shared")
+        }));
+        assert!(!dependencies
+            .iter()
+            .any(|dependency| dependency.name == "rspec"));
+        assert!(dependencies
+            .iter()
+            .any(|dependency| dependency.path == Path::new("../tools")));
+        assert!(dependencies
+            .iter()
+            .any(|dependency| dependency.path == Path::new("../api")));
+    }
+
+    #[test]
+    fn detects_gem_rake_rspec_rubocop_and_clean_targets() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemspec = tmp.path().join("sample.gemspec");
+        std::fs::write(&gemspec, "s.name = 'sample'\ns.add_dependency 'rspec'\n").unwrap();
+        std::fs::write(tmp.path().join("Gemfile"), "gem 'rubocop'\n").unwrap();
+        std::fs::write(
+            tmp.path().join("Rakefile"),
+            "RSpec::Core::RakeTask.new(:spec)\ntask :clobber\n",
+        )
+        .unwrap();
+        std::fs::create_dir(tmp.path().join("spec")).unwrap();
+
+        let targets = RubyPlugin
+            .detect_targets(&context(&gemspec, tmp.path()))
+            .unwrap();
+        assert_eq!(targets["deps"].command, "bundle install");
+        assert_eq!(
+            targets["build"].command,
+            "bundle exec gem build sample.gemspec"
+        );
+        assert_eq!(targets["test"].command, "bundle exec rspec");
+        assert_eq!(targets["lint"].command, "bundle exec rubocop");
+        assert_eq!(targets["format"].command, "bundle exec rubocop -A");
+        assert_eq!(targets["clean"].command, "bundle exec rake clobber");
+    }
+
+    #[test]
+    fn detects_rails_application_targets_and_file_selection() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemfile = tmp.path().join("Gemfile");
+        std::fs::write(&gemfile, "gem 'rails'\n").unwrap();
+        std::fs::create_dir_all(tmp.path().join("bin")).unwrap();
+        std::fs::write(tmp.path().join("bin/rails"), "#!/usr/bin/env ruby\n").unwrap();
+        std::fs::create_dir(tmp.path().join("test")).unwrap();
+
+        let targets = RubyPlugin
+            .detect_targets(&context(&gemfile, tmp.path()))
+            .unwrap();
+        assert_eq!(targets["test"].command, "bin/rails test");
+        assert!(targets["dev"].stream);
+        let command = RubyPlugin
+            .with_files_list(
+                "test",
+                "bin/rails test",
+                &[
+                    PathBuf::from("app/models/user.rb"),
+                    PathBuf::from("test/models/user_test.rb"),
+                ],
+            )
+            .unwrap();
+        assert_eq!(command, "bin/rails test test/models/user_test.rb");
+    }
+
+    #[test]
+    fn skips_duplicate_and_fixture_gemspecs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let first = tmp.path().join("a.gemspec");
+        let second = tmp.path().join("b.gemspec");
+        std::fs::write(&first, "").unwrap();
+        std::fs::write(&second, "").unwrap();
+        assert!(!RubyPlugin.should_skip(&first));
+        assert!(RubyPlugin.should_skip(&second));
+
+        let fixture = tmp.path().join("spec/fixtures/example/example.gemspec");
+        std::fs::create_dir_all(fixture.parent().unwrap()).unwrap();
+        std::fs::write(&fixture, "").unwrap();
+        assert!(RubyPlugin.should_skip(&fixture));
+    }
+
+    #[test]
+    fn build_supports_strict_warnings_and_cache_boundaries() {
+        assert_eq!(
+            RubyPlugin.with_warnings_as_errors("build", "bundle exec gem build sample.gemspec"),
+            Some("bundle exec gem build sample.gemspec --strict".to_string())
+        );
+        assert!(RubyPlugin.cache_inputs("deps").source_globs.is_empty());
+        assert!(RubyPlugin
+            .cache_inputs("test")
+            .source_globs
+            .contains(&"spec/**/*".to_string()));
+    }
+
+    #[test]
+    fn ancestor_gemfile_disables_member_cache_to_avoid_stale_lockfile_results() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("Gemfile"),
+            "source 'https://rubygems.org'\n",
+        )
+        .unwrap();
+        let member = tmp.path().join("gems/member");
+        std::fs::create_dir_all(member.join("spec")).unwrap();
+        std::fs::write(member.join(".rspec"), "").unwrap();
+        let gemspec = member.join("member.gemspec");
+        std::fs::write(&gemspec, "s.name = 'member'\n").unwrap();
+
+        let targets = RubyPlugin
+            .detect_targets(&context(&gemspec, tmp.path()))
+            .unwrap();
+        assert!(targets.values().all(|target| {
+            target.cache.as_ref().and_then(|cache| cache.enabled) == Some(false)
+        }));
+    }
+
+    #[test]
+    fn gemspec_without_gemfile_uses_rubygems_and_rake_without_fake_deps_target() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gemspec = tmp.path().join("standalone.gemspec");
+        std::fs::write(&gemspec, "s.name = 'standalone'\n").unwrap();
+        std::fs::create_dir(tmp.path().join("test")).unwrap();
+        std::fs::write(tmp.path().join("Rakefile"), "Rake::TestTask.new\n").unwrap();
+
+        let targets = RubyPlugin
+            .detect_targets(&context(&gemspec, tmp.path()))
+            .unwrap();
+        assert!(!targets.contains_key("deps"));
+        assert_eq!(targets["build"].command, "gem build standalone.gemspec");
+        assert_eq!(targets["test"].command, "rake test");
+        assert!(targets["build"].depends_on.is_empty());
+    }
+}

--- a/src/watch/event_loop.rs
+++ b/src/watch/event_loop.rs
@@ -494,6 +494,8 @@ mod tests {
             dependencies: vec![],
             targets: target_map,
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(rel),
         }
     }

--- a/src/watch/plan.rs
+++ b/src/watch/plan.rs
@@ -224,6 +224,8 @@ mod tests {
             dependencies: vec![],
             targets: target_map,
             plugin_name: "nodejs".to_string(),
+            languages: vec!["nodejs".to_string()],
+            build_system: None,
             relative_path: PathBuf::from(rel),
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,6 +44,13 @@ fn write_pyproject_toml(tmp: &TempDir, path: &str, content: &str) {
     fs::write(full_path, content).unwrap();
 }
 
+/// Write an arbitrary fixture file, creating parent directories.
+fn write_fixture(tmp: &TempDir, path: &str, content: &str) {
+    let full_path = tmp.path().join(path);
+    fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+    fs::write(full_path, content).unwrap();
+}
+
 #[test]
 fn dev_target_does_not_conflict_with_services_command() {
     let tmp = TempDir::new().unwrap();
@@ -146,6 +153,34 @@ cache = { enabled = false }
     assert_eq!(
         fs::read_to_string(tmp.path().join("app/quoted.txt")).unwrap(),
         "two words"
+    );
+}
+
+#[test]
+fn stale_execution_log_is_absent_while_native_target_runs() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_package_json(
+        &tmp,
+        "app/package.json",
+        r#"{"name":"app","scripts":{"test":"test ! -e ../.aster/logs/latest.json"}}"#,
+    );
+    write_fixture(
+        &tmp,
+        ".aster/logs/latest.json",
+        r#"{"timestamp":"old","target":"test","results":[]}"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["--no-cache", "test", "//app", "--no-deps"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    assert!(
+        tmp.path().join(".aster/logs/latest.json").is_file(),
+        "Aster should recreate the run log after native tools finish"
     );
 }
 
@@ -576,6 +611,155 @@ utils = {path = "../../libs/utils"}
         stdout.contains("//libs/utils"),
         "Expected //libs/utils in dependency output: {stdout}"
     );
+}
+
+#[cfg(unix)]
+#[test]
+fn gradle_module_target_executes_wrapper_from_build_root() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(
+        &tmp,
+        "settings.gradle.kts",
+        r#"rootProject.name = "sample"
+include("shared", "app")
+"#,
+    );
+    write_fixture(&tmp, "shared/shared.gradle.kts", "plugins { java }\n");
+    write_fixture(
+        &tmp,
+        "app/app.gradle.kts",
+        "plugins { java }\ndependencies { implementation(project(\":shared\")) }\n",
+    );
+    write_fixture(
+        &tmp,
+        "gradlew",
+        "#!/bin/sh\nprintf '%s\\n' \"$PWD|$*\" >> wrapper-invocations\n",
+    );
+    let wrapper = tmp.path().join("gradlew");
+    let mut permissions = fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&wrapper, permissions).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["--no-cache", "build", "//app", "--no-deps"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let invocation = fs::read_to_string(tmp.path().join("wrapper-invocations")).unwrap();
+    assert!(
+        invocation.contains("|:app:build"),
+        "expected scoped Gradle task: {invocation}"
+    );
+    assert!(
+        invocation.starts_with(
+            &tmp.path()
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        ),
+        "wrapper should run at Gradle root: {invocation}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn maven_module_target_executes_wrapper_with_reactor_selection() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(
+        &tmp,
+        "pom.xml",
+        "<project><artifactId>parent</artifactId><packaging>pom</packaging><modules><module>shared</module><module>app</module></modules></project>",
+    );
+    write_fixture(
+        &tmp,
+        "shared/pom.xml",
+        "<project><artifactId>shared</artifactId></project>",
+    );
+    write_fixture(
+        &tmp,
+        "shared/src/main/java/Shared.java",
+        "class Shared {}\n",
+    );
+    write_fixture(
+        &tmp,
+        "app/pom.xml",
+        "<project><artifactId>app</artifactId><dependencies><dependency><groupId>dev.example</groupId><artifactId>shared</artifactId></dependency></dependencies></project>",
+    );
+    write_fixture(&tmp, "app/src/main/java/App.java", "class App {}\n");
+    write_fixture(
+        &tmp,
+        "mvnw",
+        "#!/bin/sh\nprintf '%s\\n' \"$PWD|$*\" >> wrapper-invocations\n",
+    );
+    let wrapper = tmp.path().join("mvnw");
+    let mut permissions = fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&wrapper, permissions).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["--no-cache", "test", "//app", "--no-deps"])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let invocation = fs::read_to_string(tmp.path().join("wrapper-invocations")).unwrap();
+    assert!(
+        invocation.contains("|-pl :app -am test"),
+        "expected Maven reactor selection: {invocation}"
+    );
+    assert!(
+        invocation.starts_with(
+            &tmp.path()
+                .canonicalize()
+                .unwrap()
+                .to_string_lossy()
+                .to_string()
+        ),
+        "wrapper should run at Maven reactor root: {invocation}"
+    );
+}
+
+#[test]
+fn gradle_and_maven_are_valid_language_filters() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(&tmp, "gradle-app/build.gradle", "apply plugin: 'java'\n");
+    write_fixture(
+        &tmp,
+        "maven-app/pom.xml",
+        "<project><artifactId>maven-app</artifactId></project>",
+    );
+    write_fixture(&tmp, "maven-app/src/main/java/App.java", "class App {}\n");
+
+    let gradle = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["list", "--lang", "gradle"])
+        .output()
+        .unwrap();
+    assert!(gradle.status.success(), "Command failed: {gradle:?}");
+    let stdout = String::from_utf8_lossy(&gradle.stdout);
+    assert!(stdout.contains("//gradle-app"));
+    assert!(!stdout.contains("//maven-app"));
+
+    let maven = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["list", "--lang", "maven"])
+        .output()
+        .unwrap();
+    assert!(maven.status.success(), "Command failed: {maven:?}");
+    let stdout = String::from_utf8_lossy(&maven.stdout);
+    assert!(stdout.contains("//maven-app"));
+    assert!(!stdout.contains("//gradle-app"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -729,6 +729,94 @@ fn maven_module_target_executes_wrapper_with_reactor_selection() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn ruby_member_executes_bundle_install_at_root_and_rspec_in_member() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(&tmp, "Gemfile", "source 'https://rubygems.org'\n");
+    write_fixture(
+        &tmp,
+        "gems/core/core.gemspec",
+        "Gem::Specification.new { |s| s.name = 'core' }\n",
+    );
+    write_fixture(&tmp, "gems/core/.rspec", "--color\n");
+    write_fixture(&tmp, "gems/core/spec/core_spec.rb", "# fixture\n");
+    write_fixture(
+        &tmp,
+        "bin/bundle",
+        "#!/bin/sh\nprintf '%s|%s\\n' \"$PWD\" \"$*\" >> \"$ASTER_RUBY_LOG\"\n",
+    );
+    let wrapper = tmp.path().join("bin/bundle");
+    let mut permissions = fs::metadata(&wrapper).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&wrapper, permissions).unwrap();
+
+    let path = format!(
+        "{}:{}",
+        tmp.path().join("bin").display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+    let log = tmp.path().join("bundle-invocations");
+    for (target, address) in [("deps", "//gems/core"), ("test", "//gems/core")] {
+        let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+            .current_dir(tmp.path())
+            .env("PATH", &path)
+            .env("ASTER_RUBY_LOG", &log)
+            .args(["--no-cache", target, address, "--no-deps"])
+            .output()
+            .unwrap();
+        assert!(output.status.success(), "Command failed: {output:?}");
+    }
+
+    let invocations = fs::read_to_string(log).unwrap();
+    let root = tmp.path().canonicalize().unwrap();
+    assert!(
+        invocations.contains(&format!("{}|install", root.display())),
+        "bundle install should run at the nearest Gemfile: {invocations}"
+    );
+    assert!(
+        invocations.contains(&format!("{}|exec rspec", root.join("gems/core").display())),
+        "RSpec should run in the selected gem: {invocations}"
+    );
+}
+
+#[test]
+fn ruby_gem_takes_precedence_over_colocated_javascript_assets() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(&tmp, "app/Gemfile", "gemspec\n");
+    write_fixture(
+        &tmp,
+        "app/app.gemspec",
+        "Gem::Specification.new { |s| s.name = 'app' }\n",
+    );
+    write_package_json(
+        &tmp,
+        "app/package.json",
+        r#"{"name":"app-assets","scripts":{"build":"vite build"}}"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["list", "--lang", "ruby"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("//app"));
+
+    let node = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["list", "--lang", "nodejs"])
+        .output()
+        .unwrap();
+    assert!(node.status.success(), "Command failed: {node:?}");
+    assert!(!String::from_utf8_lossy(&node.stdout).contains("//app"));
+}
+
 #[test]
 fn gradle_and_maven_are_valid_language_filters() {
     let tmp = TempDir::new().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -818,36 +818,125 @@ fn ruby_gem_takes_precedence_over_colocated_javascript_assets() {
 }
 
 #[test]
-fn gradle_and_maven_are_valid_language_filters() {
+fn java_and_kotlin_filters_are_independent_from_jvm_build_systems() {
     let tmp = TempDir::new().unwrap();
     setup_workspace(&tmp);
-    write_fixture(&tmp, "gradle-app/build.gradle", "apply plugin: 'java'\n");
+    write_fixture(&tmp, "gradle-java/build.gradle", "apply plugin: 'java'\n");
     write_fixture(
         &tmp,
-        "maven-app/pom.xml",
-        "<project><artifactId>maven-app</artifactId></project>",
+        "gradle-kotlin/build.gradle.kts",
+        "plugins { kotlin(\"jvm\") version \"2.1.0\" }\n",
     );
-    write_fixture(&tmp, "maven-app/src/main/java/App.java", "class App {}\n");
+    write_fixture(
+        &tmp,
+        "gradle-mixed/build.gradle.kts",
+        "plugins { kotlin(\"jvm\") version \"2.1.0\" }\n",
+    );
+    write_fixture(
+        &tmp,
+        "gradle-mixed/src/main/java/App.java",
+        "class App {}\n",
+    );
+    write_fixture(&tmp, "gradle-mixed/src/main/kotlin/App.kt", "class App\n");
+    write_fixture(
+        &tmp,
+        "maven-java/pom.xml",
+        "<project><artifactId>maven-java</artifactId></project>",
+    );
+    write_fixture(&tmp, "maven-java/src/main/java/App.java", "class App {}\n");
+    write_fixture(
+        &tmp,
+        "maven-kotlin/pom.xml",
+        "<project><artifactId>maven-kotlin</artifactId><build><plugins><plugin><artifactId>kotlin-maven-plugin</artifactId></plugin></plugins></build></project>",
+    );
+    write_fixture(&tmp, "maven-kotlin/src/main/kotlin/App.kt", "class App\n");
 
-    let gradle = Command::new(env!("CARGO_BIN_EXE_aster"))
+    let java = Command::new(env!("CARGO_BIN_EXE_aster"))
         .current_dir(tmp.path())
-        .args(["list", "--lang", "gradle"])
+        .args(["list", "--lang", "java"])
         .output()
         .unwrap();
-    assert!(gradle.status.success(), "Command failed: {gradle:?}");
-    let stdout = String::from_utf8_lossy(&gradle.stdout);
-    assert!(stdout.contains("//gradle-app"));
-    assert!(!stdout.contains("//maven-app"));
+    assert!(java.status.success(), "Command failed: {java:?}");
+    let stdout = String::from_utf8_lossy(&java.stdout);
+    assert!(stdout.contains("//gradle-java"));
+    assert!(stdout.contains("//maven-java"));
+    assert!(stdout.contains("//gradle-mixed"));
+    assert!(!stdout.contains("//gradle-kotlin"));
+    assert!(!stdout.contains("//maven-kotlin"));
 
-    let maven = Command::new(env!("CARGO_BIN_EXE_aster"))
+    let kotlin = Command::new(env!("CARGO_BIN_EXE_aster"))
         .current_dir(tmp.path())
-        .args(["list", "--lang", "maven"])
+        .args(["list", "--lang", "kotlin"])
         .output()
         .unwrap();
-    assert!(maven.status.success(), "Command failed: {maven:?}");
-    let stdout = String::from_utf8_lossy(&maven.stdout);
-    assert!(stdout.contains("//maven-app"));
-    assert!(!stdout.contains("//gradle-app"));
+    assert!(kotlin.status.success(), "Command failed: {kotlin:?}");
+    let stdout = String::from_utf8_lossy(&kotlin.stdout);
+    assert!(stdout.contains("//gradle-kotlin"));
+    assert!(stdout.contains("//maven-kotlin"));
+    assert!(stdout.contains("//gradle-mixed"));
+    assert!(!stdout.contains("//gradle-java"));
+    assert!(!stdout.contains("//maven-java"));
+}
+
+#[test]
+fn gradle_kotlin_dsl_does_not_imply_kotlin_source() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(&tmp, "app/build.gradle.kts", "plugins { java }\n");
+
+    let java = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["list", "--lang", "java"])
+        .output()
+        .unwrap();
+    assert!(java.status.success(), "Command failed: {java:?}");
+    assert!(String::from_utf8_lossy(&java.stdout).contains("//app"));
+
+    let kotlin = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["list", "--lang", "kotlin"])
+        .output()
+        .unwrap();
+    assert!(kotlin.status.success(), "Command failed: {kotlin:?}");
+    assert!(!String::from_utf8_lossy(&kotlin.stdout).contains("//app"));
+}
+
+#[test]
+fn list_json_reports_languages_and_build_system_separately() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(&tmp, "app/build.gradle", "apply plugin: 'java'\n");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["--json", "list"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "Command failed: {output:?}");
+    let projects: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(projects[0]["languages"], serde_json::json!(["java"]));
+    assert_eq!(projects[0]["build_system"], "gradle");
+    assert_eq!(projects[0]["plugin"], "gradle");
+}
+
+#[test]
+fn gradle_and_maven_are_not_language_filters() {
+    let tmp = TempDir::new().unwrap();
+    setup_workspace(&tmp);
+    write_fixture(&tmp, "app/build.gradle", "apply plugin: 'java'\n");
+
+    for build_system in ["gradle", "maven"] {
+        let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+            .current_dir(tmp.path())
+            .args(["list", "--lang", build_system])
+            .output()
+            .unwrap();
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains(&format!("Unknown language '{build_system}'")));
+        assert!(stderr.contains("java"));
+        assert!(stderr.contains("kotlin"));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- model source languages independently from the plugin backend and build system
- expose Java and Kotlin as `--lang` values across Gradle and Maven; Gradle and Maven are no longer accepted as languages
- detect mixed Java/Kotlin projects from source files and build configuration without treating top-level Kotlin DSL files as Kotlin source
- report `languages` and `build_system` separately in JSON project output
- add Gradle and Maven JVM project discovery, native wrapper execution, multi-project/reactor scoping, targets, and cache inputs
- add Ruby discovery for Gemfile and gemspec projects with Bundler, RubyGems, Rake, RSpec, Rails, and RuboCop targets
- resolve Ruby sibling gems statically without evaluating project configuration and prevent Ruby/Node address collisions

## Real-project validation

### JVM

- OpenTelemetry Java Examples: detected 30 Gradle modules (29 Java, one Kotlin); Aster-driven Java and Kotlin module test targets both passed on JDK 17
- Spring Petclinic: detected one Java project and selected Maven in the dual-build checkout; dependency resolution and all 73 tests passed through Aster on JDK 17 with an isolated Postgres port
- JUnit 5: detected 40 projects, including Java, Kotlin, mixed-source, precompiled Kotlin script-plugin, custom Gradle filename, and Maven fixture cases; graph validation passed (current main requires JDK 25 for tests)
- Maven Resolver: detected 28 Java Maven reactor modules while excluding embedded integration-test POMs; graph validation passed (current main requires JDK 21 for tests)
- all four repositories passed `--lang java` and `--lang kotlin` result-membership assertions, and every project reports its Gradle/Maven build system separately

### Ruby

- Rack: bundle install, full Rake test suite, and strict gem packaging passed through Aster
- RSpec: detected six Ruby projects; root dependency installation and the rspec-support test target passed through Aster
- Rails: detected 15 Ruby projects with multi-gem relationships and deterministic ownership over colocated JavaScript assets
- Rake: Aster ran all 606 upstream tests; 602 passed and four failed only on Homebrew symlink-versus-Cellar path assertions

## Verification

- `cargo fmt --check`
- `cargo test --all-targets --all-features` (553 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`
- `git diff --check`