### PR TITLE
Bug bash and fuzz Aster configuration parsing

### DIFF
--- a/docs/bug-bash/2026-08-03-configuration.md
+++ b/docs/bug-bash/2026-08-03-configuration.md
@@ -1,0 +1,70 @@
+# Configuration bug bash — 2026-08-03
+
+Scope: every field in the `aster.toml` project/workspace models, strict unknown-field handling, malformed and boundary values, semantic dependency/capability/glob validation, and mutation fuzzing. Every scenario is sent through both public loading paths: `parse_aster_toml` and `WorkspaceConfig::load`.
+
+## Harness
+
+`tests/config_bug_bash.rs` is a deterministic regression harness with two layers:
+
+- a named matrix of 38 valid, invalid, boundary, and cross-field scenarios;
+- 10,000 reproducible mutations across seven representative seed documents, including delimiter, quote, newline, NUL, comment, address, and Unicode insertions.
+
+The fuzz seed is fixed (`0x6a09e667f3bcc909`), inputs are bounded, and panics report the mutation index and PRNG state. The harness has no new dependencies and runs in about one second locally.
+
+## Running log
+
+| # | Configuration tried | Expected | Result / observation |
+|---:|---|---|---|
+| 1 | Empty document | accept | Both loaders returned defaults. |
+| 2 | Comment-only document | accept | Both loaders ignored comments. |
+| 3 | Unicode project name (`服务-🚀`) | accept | UTF-8 survived both loaders. |
+| 4 | Simple string target | accept | Command preserved. |
+| 5 | Rich target with all non-cache fields | accept | Capability, glob, streaming, invalidation, and exclusive resource fields parsed. |
+| 6 | Alias target with `//self:` dependency | accept | Alias shape and dependency parsed. |
+| 7 | Root dependencies with and without target suffix | accept | Both address forms parsed. |
+| 8 | Multiple discovery ignore globs | accept | Lists parsed consistently. |
+| 9 | Watch ignores, suppression, and maximum TOML integer debounce | accept | Signed TOML boundary (`i64::MAX`) converted safely to `u64`. |
+| 10 | Affected ignore configuration | accept | Workspace/project views agreed. |
+| 11 | Fixed port at 65535 | accept | Upper `u16` boundary accepted. |
+| 12 | Resolved port with scalar `env` | accept | One-or-many scalar form accepted. |
+| 13 | Resolved port with list `env` and empty `file_env` | accept | List form and explicit empty override accepted. |
+| 14 | Derived port with saturation | accept | Offset fields and boolean parsed. |
+| 15 | Full development service with minimum `i32` order | accept | Service strings, maps, lists, and order boundary parsed. |
+| 16 | Full cache override | accept | Enabled/include/exclude/env/outputs parsed. |
+| 17 | Quoted target containing a colon | accept | Legal TOML dotted-key escaping preserved the target name. |
+| 18 | Literal multiline command | accept | Quotes and embedded newline preserved. |
+| 19 | Unknown top-level key | reject | Strict root schema rejected it. |
+| 20 | Unknown watch key | reject | Strict nested schema rejected it. |
+| 21 | Unknown affected key | reject | Strict nested schema rejected it. |
+| 22 | Unknown dev key | reject | Strict nested schema rejected it. |
+| 23 | Unknown port key | reject | Untagged port variant rejected it. |
+| 24 | Unknown service key | reject | Strict service schema rejected it. |
+| 25 | Unknown rich-target key | reject | Strict target schema rejected it. |
+| 26 | Unknown alias key | reject | No untagged target variant accepted it. |
+| 27 | Unknown cache key | reject | Strict cache schema rejected it. |
+| 28 | Malformed table header | reject | TOML parser returned an error, no panic. |
+| 29 | Duplicate project-name key | reject | TOML parser rejected duplication. |
+| 30 | Integer supplied for project name | reject | Serde type check rejected it. |
+| 31 | Mixed string/integer dependency list | reject | Serde type check rejected it. |
+| 32 | Root dependency without `//` | reject | **Bug found:** workspace loader originally accepted it while project loader rejected it. Fixed with shared semantic validation. |
+| 33 | Rich-target dependency without `//` | reject | **Bug found:** both loaders originally skipped nested dependency validation. Fixed and retained as regression coverage. |
+| 34 | Alias dependency without `//` | reject | Same nested-dependency bug; fixed and covered separately. |
+| 35 | Misspelled capability (`file_list`) | reject | Workspace loader now matches project-loader semantic rejection. |
+| 36 | Invalid `files_glob` | reject | Workspace loader now compiles and rejects the glob too. |
+| 37 | Invalid cache include glob | reject | Workspace loader now compiles and rejects the glob too. |
+| 38 | Unterminated string | reject | TOML parser returned an error, no panic. |
+| 39 | 10,000 deterministic delimiter/Unicode/NUL mutations | accept or reject, never panic | Completed without panic in either loader. |
+
+## Bugs and regression fixes
+
+1. Root configuration validation depended on the command path. `WorkspaceConfig::load` only deserialized while `parse_aster_toml` also checked dependency addresses, capabilities, and globs. Shared `validate_aster_config` now runs after both deserializers. Scenarios 32 and 35–37 are regression cases.
+2. Rich and alias target `depends_on` entries were never address-validated by either loader. They now receive the same contextual validation as top-level dependencies. Scenarios 33–34 are regression cases.
+
+## Verification log
+
+- Pre-change baseline: `cargo test --all-targets` — 553 passed, 0 failed.
+- Harness after fixes: `cargo test --test config_bug_bash -- --nocapture` — 2 passed, including 38 matrix cases and 10,000 mutations.
+- Focused existing suite: `cargo test config:: --lib` — 36 passed.
+- Full suite: `cargo test --locked --all-targets --all-features` — 555 passed, 0 failed.
+- Static/documentation gates: strict Clippy, rustfmt check, diff check, and rustdoc with warnings denied all passed.
+- `cargo audit` was not available in the environment and was not installed as part of this bug bash.

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -222,13 +222,35 @@ pub fn parse_aster_toml(path: &Path) -> Result<AsterToml> {
     let config: AsterToml =
         toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
 
-    // Validate depends_on entries are valid addresses
-    for dep in &config.depends_on {
+    validate_aster_config(&config.depends_on, &config.targets, path)?;
+
+    Ok(config)
+}
+
+/// Validate fields shared by the project and workspace views of aster.toml.
+///
+/// The root file is deserialized through both views by different commands, so
+/// semantic validity must not depend on which command happened to load it.
+pub(super) fn validate_aster_config(
+    depends_on: &[String],
+    targets: &HashMap<String, TargetConfig>,
+    path: &Path,
+) -> Result<()> {
+    for dep in depends_on {
         Address::parse(dep)
             .with_context(|| format!("Invalid dependency '{}' in {}", dep, path.display()))?;
     }
 
-    for (target_name, target) in &config.targets {
+    for (target_name, target) in targets {
+        for dep in target.depends_on() {
+            Address::parse(dep).with_context(|| {
+                format!(
+                    "Invalid dependency '{dep}' for target '{target_name}' in {}",
+                    path.display()
+                )
+            })?;
+        }
+
         let TargetConfig::Rich(target) = target else {
             continue;
         };
@@ -264,7 +286,7 @@ pub fn parse_aster_toml(path: &Path) -> Result<AsterToml> {
         }
     }
 
-    Ok(config)
+    Ok(())
 }
 
 /// Check if an aster.toml file exists in the given project directory

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use super::project::TargetConfig;
+use super::project::{validate_aster_config, TargetConfig};
 
 /// Workspace-level configuration from the root aster.toml
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -184,6 +184,8 @@ impl WorkspaceConfig {
         // Parse TOML - workspace config fields are at the top level
         let config: WorkspaceConfig = toml::from_str(&content)
             .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+
+        validate_aster_config(&config.depends_on, &config.targets, &config_path)?;
 
         Ok(config)
     }

--- a/tests/config_bug_bash.rs
+++ b/tests/config_bug_bash.rs
@@ -1,0 +1,129 @@
+//! Deterministic configuration bug-bash and fuzz regression harness.
+//!
+//! Keep this test dependency-free and reproducible: failures print the seed and
+//! mutation number so a malformed input can be promoted to a focused test.
+
+use aster::config::{parse_aster_toml, WorkspaceConfig};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use tempfile::TempDir;
+
+#[derive(Clone, Copy, Debug)]
+enum Expected {
+    Accept,
+    Reject,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Scenario {
+    name: &'static str,
+    input: &'static str,
+    expected: Expected,
+}
+
+fn parse_both(input: &str) -> (bool, bool) {
+    let temp = TempDir::new().expect("create config scenario directory");
+    let path = temp.path().join("aster.toml");
+    std::fs::write(&path, input).expect("write config scenario");
+    (
+        parse_aster_toml(&path).is_ok(),
+        WorkspaceConfig::load(temp.path()).is_ok(),
+    )
+}
+
+#[test]
+fn configuration_scenario_matrix() {
+    let scenarios = [
+        Scenario { name: "empty document", input: "", expected: Expected::Accept },
+        Scenario { name: "comments only", input: "# aster workspace\n", expected: Expected::Accept },
+        Scenario { name: "unicode project name", input: "name = \"服务-🚀\"\n", expected: Expected::Accept },
+        Scenario { name: "simple target", input: "[targets]\ntest = \"cargo test\"\n", expected: Expected::Accept },
+        Scenario { name: "rich target", input: "[targets.test]\ncommand = \"pytest {files}\"\ncapabilities = [\"files_list\"]\nfiles_glob = \"**/*_test.py\"\nstream = false\ninvalidates_cache = false\nexclusive_resources = [\"python-env\"]\n", expected: Expected::Accept },
+        Scenario { name: "alias target", input: "[targets]\ntest = \"cargo test\"\ncheck = { alias = \"test\", depends_on = [\"//self:lint\"] }\n", expected: Expected::Accept },
+        Scenario { name: "root dependencies", input: "depends_on = [\"//libs/a:build\", \"//libs/b\"]\n", expected: Expected::Accept },
+        Scenario { name: "discovery ignores", input: "ignore = [\"vendor/**\", \"examples/**\"]\n", expected: Expected::Accept },
+        Scenario { name: "watch configuration", input: "[watch]\nignore = [\"coverage/**\"]\nsuppress_paths = [\"dist/**\"]\ndebounce_ms = 9223372036854775807\n", expected: Expected::Accept },
+        Scenario { name: "affected configuration", input: "[affected]\nignore = [\"docs/**\"]\n", expected: Expected::Accept },
+        Scenario { name: "fixed boundary port", input: "[dev.ports]\nhttp = 65535\n", expected: Expected::Accept },
+        Scenario { name: "resolved port one env", input: "[dev.ports.http]\nenv = \"PORT\"\ndefault = 4000\n", expected: Expected::Accept },
+        Scenario { name: "resolved port many env", input: "[dev.ports.http]\nenv = [\"PORT\", \"HTTP_PORT\"]\nfile_env = []\ndefault = 4000\n", expected: Expected::Accept },
+        Scenario { name: "derived port", input: "[dev.ports.base]\ndefault = 4000\n[dev.ports.web]\ndefault = 3000\noffset_from = \"base\"\noffset_base = 4000\nsaturating_offset = true\n", expected: Expected::Accept },
+        Scenario { name: "development service", input: "[dev.services.api]\ntarget = \"//api:dev\"\nport = \"http\"\nopen_path = \"/health\"\nenv_files = [\".env\"]\nenv = { PORT = \"{port}\" }\ninherit_env = [\"PATH\"]\norder = -2147483648\n", expected: Expected::Accept },
+        Scenario { name: "cache configuration", input: "[targets.build]\ncommand = \"cargo build\"\n[targets.build.cache]\nenabled = true\ninclude = [\"src/**\"]\nexclude = [\"**/*.tmp\"]\nenv = [\"RUSTFLAGS\"]\noutputs = [\"target/debug/app\"]\n", expected: Expected::Accept },
+        Scenario { name: "quoted dotted target", input: "[targets.\"check:all\"]\ncommand = \"true\"\n", expected: Expected::Accept },
+        Scenario { name: "literal multiline command", input: "[targets.run]\ncommand = '''printf 'one\\ntwo' '''\n", expected: Expected::Accept },
+        Scenario { name: "unknown top-level key", input: "mystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown watch key", input: "[watch]\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown affected key", input: "[affected]\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown dev key", input: "[dev]\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown port key", input: "[dev.ports.http]\ndefault = 4000\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown service key", input: "[dev.services.api]\ntarget = \"//api:dev\"\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown target key", input: "[targets.test]\ncommand = \"true\"\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown alias key", input: "[targets.check]\nalias = \"test\"\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "unknown cache key", input: "[targets.test]\ncommand = \"true\"\n[targets.test.cache]\nmystery = true\n", expected: Expected::Reject },
+        Scenario { name: "malformed table", input: "[targets.test\ncommand = \"true\"\n", expected: Expected::Reject },
+        Scenario { name: "duplicate key", input: "name = \"a\"\nname = \"b\"\n", expected: Expected::Reject },
+        Scenario { name: "wrong scalar type", input: "name = 42\n", expected: Expected::Reject },
+        Scenario { name: "wrong list member type", input: "depends_on = [\"//a\", 42]\n", expected: Expected::Reject },
+        Scenario { name: "invalid root dependency", input: "depends_on = [\"not-an-address\"]\n", expected: Expected::Reject },
+        Scenario { name: "invalid rich target dependency", input: "[targets.test]\ncommand = \"true\"\ndepends_on = [\"lint\"]\n", expected: Expected::Reject },
+        Scenario { name: "invalid alias dependency", input: "[targets]\ntest = \"true\"\ncheck = { alias = \"test\", depends_on = [\"lint\"] }\n", expected: Expected::Reject },
+        Scenario { name: "unsupported capability", input: "[targets.test]\ncommand = \"true\"\ncapabilities = [\"file_list\"]\n", expected: Expected::Reject },
+        Scenario { name: "invalid files glob", input: "[targets.test]\ncommand = \"true\"\nfiles_glob = \"[\"\n", expected: Expected::Reject },
+        Scenario { name: "invalid cache glob", input: "[targets.test]\ncommand = \"true\"\n[targets.test.cache]\ninclude = [\"[\"]\n", expected: Expected::Reject },
+        Scenario { name: "unterminated string", input: "name = \"aster\n", expected: Expected::Reject },
+    ];
+
+    for scenario in scenarios {
+        let (project, workspace) = parse_both(scenario.input);
+        let expected = matches!(scenario.expected, Expected::Accept);
+        assert_eq!(project, expected, "project parser: {}", scenario.name);
+        assert_eq!(workspace, expected, "workspace parser: {}", scenario.name);
+    }
+}
+
+#[test]
+fn deterministic_mutation_fuzz_never_panics() {
+    const SEEDS: &[&str] = &[
+        "",
+        "name = \"app\"\n",
+        "[targets.test]\ncommand = \"cargo test\"\n",
+        "[targets.test.cache]\nenabled = true\ninclude = [\"src/**\"]\n",
+        "[watch]\nignore = [\"target/**\"]\ndebounce_ms = 300\n",
+        "[dev.ports.http]\nenv = [\"PORT\"]\ndefault = 4000\n",
+        "[dev.services.api]\ntarget = \"//api:dev\"\nenv = { PORT = \"{port}\" }\n",
+    ];
+    const INSERTIONS: &[&str] = &[
+        "\0", "[", "]", "{", "}", "=", "\"", "'", "\n", "#", "//", "🚀",
+    ];
+
+    let temp = TempDir::new().expect("create fuzz directory");
+    let path = temp.path().join("aster.toml");
+    let mut state = 0x6a09_e667_f3bc_c909_u64;
+
+    for mutation in 0..10_000 {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        let seed = SEEDS[state as usize % SEEDS.len()];
+        let split = state.rotate_left(19) as usize % (seed.len() + 1);
+        let split = (0..=split)
+            .rev()
+            .find(|index| seed.is_char_boundary(*index))
+            .unwrap();
+        let insertion = INSERTIONS[state.rotate_left(37) as usize % INSERTIONS.len()];
+        let mut input = String::with_capacity(seed.len() + insertion.len());
+        input.push_str(&seed[..split]);
+        input.push_str(insertion);
+        input.push_str(&seed[split..]);
+        std::fs::write(&path, input).expect("write fuzz input");
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let _ = parse_aster_toml(&path);
+            let _ = WorkspaceConfig::load(temp.path());
+        }));
+        assert!(
+            result.is_ok(),
+            "configuration parser panicked at mutation {mutation}, state {state:#x}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add a deterministic configuration bug-bash harness covering 38 named valid, invalid, boundary, and cross-field scenarios
- fuzz both configuration loading paths with 10,000 reproducible mutations
- share semantic validation between workspace and project loaders
- reject invalid rich-target and alias dependencies at parse time
- document all 39 bug-bash iterations and their outcomes

## Bugs fixed

1. Workspace-only commands skipped dependency, capability, and glob validation performed during project parsing.
2. Rich and alias target dependencies were not address-validated by either loader.

## Verification

- `cargo test --locked --all-targets --all-features` (555 passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`