### PR TITLE
fix: align release and MSRV clippy gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           toolchain: "1.88"
-      - run: cargo check --locked --all-targets
+          components: clippy
+      - run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
   audit:
     name: Dependency audit

--- a/src/plugins/ruby.rs
+++ b/src/plugins/ruby.rs
@@ -483,8 +483,7 @@ fn rake_has_task(rakefile: &str, name: &str) -> bool {
     }
     let escaped = regex::escape(name);
     Regex::new(&format!(
-        r#"(?m)^\s*task\s*(?:\(\s*)?(?::{}\b|[\"']{}[\"'])"#,
-        escaped, escaped
+        r#"(?m)^\s*task\s*(?:\(\s*)?(?::{escaped}\b|[\"']{escaped}[\"'])"#
     ))
     .expect("escaped task regex is valid")
     .is_match(rakefile)


### PR DESCRIPTION
## Summary

- satisfy Rust 1.88 Clippy in the Ruby Rake task matcher
- make PR MSRV validation run the same strict Clippy gate as tagged releases
- unblock the public v0.8.0 release before any artifacts were published

## Validation

- `rustup run 1.88.0 cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run 1.88.0 cargo test --locked --all-targets --all-features` (554 passed)