### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Build orchestration for polyglot monorepos"


### PR DESCRIPTION
## What changed

- Bump Aster from `0.8.0` to `0.9.0`.
- Prepare the merged `services kill-ports` feature for publication.

## Verification

- `rustup run 1.88.0 cargo fmt --all -- --check`
- `rustup run 1.88.0 cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run 1.88.0 cargo test --locked --all-targets --all-features` — 560 passed

## Checklist

- [x] Tests cover the behavior change
- [x] Documentation is updated where needed
- [x] No secrets, private fixtures, or generated artifacts are included
- [x] Formatting, clippy, tests, and docs pass locally