### PR TITLE
Persist bounded local service logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,11 @@ aster services up --no-ui
 aster services up --dry-run
 ```
 
+Service stdout, stderr, and Aster lifecycle messages are also persisted to
+`.aster/logs/<worktree>/<service>/logs.txt` in the workspace. Each service log
+is capped at 10 MiB; Aster truncates it and continues writing when it reaches
+the limit.
+
 Clear stale or orphaned processes from development ports before starting the
 stack again:
 

--- a/src/dev/log_files.rs
+++ b/src/dev/log_files.rs
@@ -1,0 +1,194 @@
+use std::collections::HashMap;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use super::plan::ServicePlan;
+use super::process::LogEvent;
+
+pub const SERVICE_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
+const TRUNCATION_NOTICE: &str = "[aster] log truncated after reaching the 10 MiB limit\n";
+const OVERSIZED_LINE_NOTICE: &str =
+    "[aster] log line omitted because it exceeds the 10 MiB limit\n";
+
+pub struct ServiceLogFiles {
+    files: HashMap<String, CappedLogFile>,
+}
+
+impl ServiceLogFiles {
+    pub fn open(workspace_root: &Path, services: &[ServicePlan]) -> Result<Self> {
+        Self::open_with_limit(
+            workspace_root,
+            services.iter().map(|service| service.name.as_str()),
+            SERVICE_LOG_MAX_BYTES,
+        )
+    }
+
+    fn open_with_limit<'a>(
+        workspace_root: &Path,
+        services: impl IntoIterator<Item = &'a str>,
+        max_bytes: u64,
+    ) -> Result<Self> {
+        let worktree = workspace_root
+            .file_name()
+            .and_then(|name| name.to_str())
+            .filter(|name| !name.is_empty())
+            .unwrap_or("default");
+        let base = workspace_root
+            .join(".aster")
+            .join("logs")
+            .join(encode_path_component(worktree));
+        let mut files = HashMap::new();
+
+        for service in services {
+            let directory = base.join(encode_path_component(service));
+            fs::create_dir_all(&directory).with_context(|| {
+                format!(
+                    "failed to create service log directory {}",
+                    directory.display()
+                )
+            })?;
+            let path = directory.join("logs.txt");
+            files.insert(service.to_string(), CappedLogFile::open(path, max_bytes)?);
+        }
+
+        Ok(Self { files })
+    }
+
+    pub fn write(&mut self, event: &LogEvent) {
+        if let Some(file) = self.files.get_mut(&event.service) {
+            let _ = file.write_line(&event.line);
+        }
+    }
+}
+
+struct CappedLogFile {
+    path: PathBuf,
+    file: File,
+    len: u64,
+    max_bytes: u64,
+}
+
+impl CappedLogFile {
+    fn open(path: PathBuf, max_bytes: u64) -> Result<Self> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("failed to open service log file {}", path.display()))?;
+        let len = file.metadata()?.len();
+        let mut log = Self {
+            path,
+            file,
+            len,
+            max_bytes,
+        };
+        if len > max_bytes {
+            log.truncate()?;
+        }
+        Ok(log)
+    }
+
+    fn write_line(&mut self, line: &str) -> std::io::Result<()> {
+        let line_bytes = line.len() as u64 + 1;
+        if line_bytes > self.max_bytes {
+            self.replace_with(OVERSIZED_LINE_NOTICE.as_bytes())?;
+            return Ok(());
+        }
+        if self.len + line_bytes > self.max_bytes {
+            let notice = TRUNCATION_NOTICE.as_bytes();
+            if notice.len() as u64 + line_bytes <= self.max_bytes {
+                self.replace_with(notice)?;
+            } else {
+                self.replace_with(&[])?;
+            }
+        }
+        self.file.write_all(line.as_bytes())?;
+        self.file.write_all(b"\n")?;
+        self.len += line_bytes;
+        Ok(())
+    }
+
+    fn truncate(&mut self) -> std::io::Result<()> {
+        self.replace_with(TRUNCATION_NOTICE.as_bytes())
+    }
+
+    fn replace_with(&mut self, message: &[u8]) -> std::io::Result<()> {
+        self.file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&self.path)?;
+        let message = if message.len() as u64 <= self.max_bytes {
+            message
+        } else {
+            &[]
+        };
+        self.file.write_all(message)?;
+        self.len = message.len() as u64;
+        self.file = OpenOptions::new().append(true).open(&self.path)?;
+        Ok(())
+    }
+}
+
+fn encode_path_component(value: &str) -> String {
+    let mut encoded = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.') {
+            encoded.push(char::from(byte));
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    if encoded.is_empty() {
+        "default".to_string()
+    } else if matches!(encoded.as_str(), "." | "..") {
+        encoded.replace('.', "%2E")
+    } else {
+        encoded
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_paths_are_workspace_scoped_and_components_are_safe() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("first landing-wt7");
+        fs::create_dir(&workspace).unwrap();
+        let logs =
+            ServiceLogFiles::open_with_limit(&workspace, ["../platform/backend"], 1024).unwrap();
+        drop(logs);
+
+        assert!(workspace
+            .join(".aster/logs/first%20landing-wt7/..%2Fplatform%2Fbackend/logs.txt")
+            .is_file());
+    }
+
+    #[test]
+    fn log_file_never_exceeds_its_cap() {
+        let temp = tempfile::tempdir().unwrap();
+        let workspace = temp.path().join("firstlanding-wt7");
+        fs::create_dir(&workspace).unwrap();
+        let mut logs =
+            ServiceLogFiles::open_with_limit(&workspace, ["platform-backend"], 80).unwrap();
+        let event = |line: &str| LogEvent {
+            service: "platform-backend".to_string(),
+            line: line.to_string(),
+            stderr: false,
+        };
+
+        for index in 0..20 {
+            logs.write(&event(&format!("service output line {index}")));
+        }
+        logs.write(&event(&"y".repeat(70)));
+        let path = workspace.join(".aster/logs/firstlanding-wt7/platform-backend/logs.txt");
+        assert!(fs::metadata(&path).unwrap().len() <= 80);
+        logs.write(&event(&"x".repeat(100)));
+
+        assert!(fs::metadata(path).unwrap().len() <= 80);
+    }
+}

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -1,6 +1,7 @@
 //! Config-driven local service supervision for `aster services up`.
 
 mod dashboard;
+mod log_files;
 mod plan;
 mod port_cleanup;
 mod process;

--- a/src/dev/process.rs
+++ b/src/dev/process.rs
@@ -13,11 +13,35 @@ use crate::executor::command::parse_command;
 use crate::executor::{register_supervised_child, unregister_supervised_child};
 use crate::plugins::Target;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LogEvent {
     pub service: String,
     pub line: String,
     pub stderr: bool,
+}
+
+#[derive(Clone)]
+pub struct ProcessLogSenders {
+    dashboard: SyncSender<LogEvent>,
+    system: Sender<LogEvent>,
+    durable: Sender<LogEvent>,
+    ui: bool,
+}
+
+impl ProcessLogSenders {
+    pub fn new(
+        dashboard: SyncSender<LogEvent>,
+        system: Sender<LogEvent>,
+        durable: Sender<LogEvent>,
+        ui: bool,
+    ) -> Self {
+        Self {
+            dashboard,
+            system,
+            durable,
+            ui,
+        }
+    }
 }
 
 pub struct ServiceProcess {
@@ -40,9 +64,7 @@ impl ServiceProcess {
         target: &Target,
         project_root: &std::path::Path,
         env: &HashMap<String, String>,
-        log_tx: &SyncSender<LogEvent>,
-        system_tx: &Sender<LogEvent>,
-        ui: bool,
+        log_senders: ProcessLogSenders,
     ) -> Result<Self> {
         let parsed = parse_command(&target.command)?;
         let working_dir = target.working_dir.as_deref().unwrap_or(project_root);
@@ -104,20 +126,10 @@ impl ServiceProcess {
             service,
             false,
             stdout,
-            log_tx.clone(),
-            system_tx.clone(),
+            log_senders.clone(),
             reader_stop.clone(),
-            ui,
         );
-        let stderr_handle = spawn_reader(
-            service,
-            true,
-            stderr,
-            log_tx.clone(),
-            system_tx.clone(),
-            reader_stop.clone(),
-            ui,
-        );
+        let stderr_handle = spawn_reader(service, true, stderr, log_senders, reader_stop.clone());
 
         Ok(Self {
             #[cfg(unix)]
@@ -454,10 +466,8 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(
     service: &str,
     stderr: bool,
     reader: R,
-    tx: SyncSender<LogEvent>,
-    system_tx: Sender<LogEvent>,
+    senders: ProcessLogSenders,
     stop: Arc<AtomicBool>,
-    ui: bool,
 ) -> JoinHandle<()> {
     let service = service.to_string();
     std::thread::spawn(move || {
@@ -480,15 +490,7 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(
             };
             if read == 0 {
                 if !pending.is_empty() {
-                    forward_log_line(
-                        &service,
-                        stderr,
-                        &pending,
-                        &tx,
-                        &system_tx,
-                        ui,
-                        &mut drop_reported,
-                    );
+                    forward_log_line(&service, stderr, &pending, &senders, &mut drop_reported);
                 }
                 break;
             }
@@ -498,29 +500,13 @@ fn spawn_reader<R: std::io::Read + Send + 'static>(
                 while matches!(line.last(), Some(b'\n' | b'\r')) {
                     line.pop();
                 }
-                forward_log_line(
-                    &service,
-                    stderr,
-                    &line,
-                    &tx,
-                    &system_tx,
-                    ui,
-                    &mut drop_reported,
-                );
+                forward_log_line(&service, stderr, &line, &senders, &mut drop_reported);
             }
             const MAX_PENDING_LINE: usize = 64 * 1024;
             while pending.len() >= MAX_PENDING_LINE {
                 let mut bounded = pending.drain(..MAX_PENDING_LINE).collect::<Vec<_>>();
                 bounded.extend_from_slice(b" [aster: long line continued]");
-                forward_log_line(
-                    &service,
-                    stderr,
-                    &bounded,
-                    &tx,
-                    &system_tx,
-                    ui,
-                    &mut drop_reported,
-                );
+                forward_log_line(&service, stderr, &bounded, &senders, &mut drop_reported);
             }
         }
     })
@@ -530,27 +516,26 @@ fn forward_log_line(
     service: &str,
     stderr: bool,
     bytes: &[u8],
-    tx: &SyncSender<LogEvent>,
-    system_tx: &Sender<LogEvent>,
-    ui: bool,
+    senders: &ProcessLogSenders,
     drop_reported: &mut bool,
 ) {
     let line = String::from_utf8_lossy(bytes).into_owned();
-    if !ui {
-        let stream = if stderr { "!" } else { "|" };
-        println!("[{service}] {stream} {line}");
-        return;
-    }
     let event = LogEvent {
         service: service.to_string(),
         line,
         stderr,
     };
-    match tx.try_send(event) {
+    let _ = senders.durable.send(event.clone());
+    if !senders.ui {
+        let stream = if stderr { "!" } else { "|" };
+        println!("[{service}] {stream} {}", event.line);
+        return;
+    }
+    match senders.dashboard.try_send(event) {
         Ok(()) => *drop_reported = false,
         Err(std::sync::mpsc::TrySendError::Full(_)) => {
             if !*drop_reported {
-                let _ = system_tx.send(LogEvent {
+                let _ = senders.system.send(LogEvent {
                     service: service.to_string(),
                     line: "[aster] service output omitted while the UI was busy".to_string(),
                     stderr: true,

--- a/src/dev/runner.rs
+++ b/src/dev/runner.rs
@@ -18,8 +18,9 @@ use crate::graph::TargetGraph;
 use crate::watch::WorkspaceIgnore;
 
 use super::dashboard::{Dashboard, DashboardAction, ServiceState, TerminalGuard};
+use super::log_files::ServiceLogFiles;
 use super::plan::{DevPlan, ServicePlan};
-use super::process::{LogEvent, ServiceProcess};
+use super::process::{LogEvent, ProcessLogSenders, ServiceProcess};
 
 pub struct DevOptions {
     pub watch: bool,
@@ -60,6 +61,13 @@ pub fn run_dev(
     let ignore = WorkspaceIgnore::build(&config.watch)?;
     let (log_tx, log_rx) = mpsc::sync_channel(4000);
     let (system_tx, system_rx) = mpsc::channel();
+    let (durable_log_tx, durable_log_rx) = mpsc::channel();
+    let mut durable_logs = ServiceLogFiles::open(workspace_root, &plan.services)?;
+    let durable_log_handle = std::thread::spawn(move || {
+        while let Ok(event) = durable_log_rx.recv() {
+            durable_logs.write(&event);
+        }
+    });
     let control = plan.control_port.map(ControlServer::start).transpose()?;
     let (watch_rx, _watcher) = if options.watch {
         let (rx, watcher) = start_watcher(&plan)?;
@@ -101,7 +109,13 @@ pub fn run_dev(
                 .as_ref()
                 .is_some_and(|control| control.shutdown.load(Ordering::SeqCst))
         {
-            needs_draw |= drain_logs(&log_rx, &system_rx, &mut dashboard, options.ui);
+            needs_draw |= drain_logs(
+                &log_rx,
+                &system_rx,
+                &durable_log_tx,
+                &mut dashboard,
+                options.ui,
+            );
 
             while let Ok(result) = start_rx.try_recv() {
                 if let Some((name, handle)) = active_start.take() {
@@ -139,6 +153,7 @@ pub fn run_dev(
                         options.ui,
                         &log_tx,
                         &system_tx,
+                        &durable_log_tx,
                         &mut dashboard,
                         runtimes.get_mut(&name).expect("runtime exists"),
                         &reason,
@@ -416,7 +431,9 @@ pub fn run_dev(
     for process in &mut shutdown_processes {
         process.finish_terminate(shutdown_deadline);
     }
-    drain_logs(&log_rx, &system_rx, &mut dashboard, false);
+    drain_logs(&log_rx, &system_rx, &durable_log_tx, &mut dashboard, false);
+    drop(durable_log_tx);
+    let _ = durable_log_handle.join();
     drop(control);
     if let Some(signal) = executor::shutdown_signal() {
         std::process::exit(128 + signal);
@@ -435,6 +452,7 @@ fn begin_start_service(
     ui: bool,
     log_tx: &std::sync::mpsc::SyncSender<LogEvent>,
     system_tx: &std::sync::mpsc::Sender<LogEvent>,
+    durable_log_tx: &std::sync::mpsc::Sender<LogEvent>,
     dashboard: &mut Dashboard,
     runtime: &mut Runtime,
     reason: &str,
@@ -478,6 +496,7 @@ fn begin_start_service(
     let workspace_root = workspace_root.to_path_buf();
     let log_tx = log_tx.clone();
     let system_tx = system_tx.clone();
+    let durable_log_tx = durable_log_tx.clone();
     std::thread::spawn(move || {
         let prerequisite_run =
             run_prerequisites(&prerequisites, &workspace_root, &projects, use_cache);
@@ -528,9 +547,7 @@ fn begin_start_service(
             &target,
             &project_root,
             &env,
-            &log_tx,
-            &system_tx,
-            ui,
+            ProcessLogSenders::new(log_tx, system_tx.clone(), durable_log_tx, ui),
         ) {
             Ok(process) => StartOutcome::Running(process),
             Err(error) => {
@@ -711,19 +728,23 @@ fn is_meaningful_event(kind: &notify::EventKind) -> bool {
 fn drain_logs(
     process_rx: &Receiver<LogEvent>,
     system_rx: &Receiver<LogEvent>,
+    durable_log_tx: &std::sync::mpsc::Sender<LogEvent>,
     dashboard: &mut Dashboard,
     ui: bool,
 ) -> bool {
     let mut consumed = false;
-    for rx in [system_rx, process_rx] {
-        while let Ok(event) = rx.try_recv() {
-            consumed = true;
-            if !ui {
-                let stream = if event.stderr { "!" } else { "|" };
-                println!("[{}] {stream} {}", event.service, event.line);
-            }
-            dashboard.push_log(event);
+    while let Ok(event) = system_rx.try_recv() {
+        consumed = true;
+        let _ = durable_log_tx.send(event.clone());
+        if !ui {
+            let stream = if event.stderr { "!" } else { "|" };
+            println!("[{}] {stream} {}", event.service, event.line);
         }
+        dashboard.push_log(event);
+    }
+    while let Ok(event) = process_rx.try_recv() {
+        consumed = true;
+        dashboard.push_log(event);
     }
     consumed
 }

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -228,7 +228,7 @@ command = "sh -c 'count=$(grep -c PREPARE ../events.log 2>/dev/null || true); ec
 depends_on = ["//lib:build"]
 
 [targets.dev]
-command = "sh -c 'if [ -n \"${ASTER_AMBIENT_SECRET:-}\" ]; then echo AMBIENT_SECRET_LEAKED >> ../events.log; fi; echo INHERITED:$ASTER_ALLOWED_VALUE >> ../events.log; echo START:$ASTER_SERVICE_PORT >> ../events.log; python3 -m http.server {port} & server=$!; echo $server > ../child.pid; wait $server'"
+command = "sh -c 'echo SERVICE_STDOUT; echo SERVICE_STDERR >&2; if [ -n \"${ASTER_AMBIENT_SECRET:-}\" ]; then echo AMBIENT_SECRET_LEAKED >> ../events.log; fi; echo INHERITED:$ASTER_ALLOWED_VALUE >> ../events.log; echo START:$ASTER_SERVICE_PORT >> ../events.log; python3 -m http.server {port} & server=$!; echo $server > ../child.pid; wait $server'"
 depends_on = ["//self:prepare"]
 stream = true
 "#,
@@ -277,6 +277,15 @@ command = "sh -c 'echo BUILD >> ../events.log'"
     assert!(fs::read_to_string(&events)
         .unwrap()
         .contains("INHERITED:explicitly-allowed"));
+    let worktree = root.file_name().unwrap();
+    let durable_log = root.join(".aster/logs").join(worktree).join("web/logs.txt");
+    wait_until(Duration::from_secs(5), || {
+        let contents = fs::read_to_string(&durable_log).unwrap_or_default();
+        contents.contains("SERVICE_STDOUT")
+            && contents.contains("SERVICE_STDERR")
+            && contents.contains("starting //app:dev")
+    });
+    assert!(fs::metadata(&durable_log).unwrap().len() <= 10 * 1024 * 1024);
     let status = control_request(control_port, r#"{"command":"status"}"#);
     assert_eq!(status["ok"], true);
     assert_eq!(status["services"]["web"], "running");


### PR DESCRIPTION
## Summary

- persist service stdout, stderr, and lifecycle messages under `.aster/logs/<worktree>/<service>/logs.txt`
- cap each service log at 10 MiB and safely truncate before additional writes
- write service output before the dashboard queue so UI backpressure does not lose durable logs
- encode workspace and service names as safe path components

## Validation

- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- real `services up --no-ui` integration coverage for stdout, stderr, lifecycle output, path, and cap