### PR TITLE
Add optional service groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ dashboard:
 
 ```console
 aster services up
-aster services up api web
+aster services up intern
 aster services up --no-ui
 aster services up --dry-run
 ```
@@ -339,6 +339,19 @@ Services are mappings to ordinary `stream = true` targets. Their non-stream
 target dependencies are pre-start steps: Aster runs them before the service
 starts and again before a dependency-triggered or manual restart. The same
 transitive target graph determines which project directories are watched.
+
+Services can be collected into named groups in the root `aster.toml`:
+
+```toml
+[dev.service_groups]
+main = ["platform", "developer-portal", "user-portal", "agent-network"]
+intern = ["intern-postgres", "intern-data", "intern-ctl", "intern-gateway", "intern-fe"]
+```
+
+`aster services up intern` runs that group. With no group argument, Aster runs
+the `main` group plus services that do not appear in any group. When no `main`
+group exists, the default remains all ungrouped services. A service may belong
+to more than one group.
 
 The dashboard uses scalable colored service tabs beside one focused log
 stream. Use `h`/`l` or click a tab to switch services, drag the divider or use

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -259,8 +259,8 @@ pub enum Commands {
 pub enum ServicesCommands {
     /// Start configured services in a supervised dashboard
     Up {
-        /// Service names from `[dev.services]` (defaults to all services)
-        services: Vec<String>,
+        /// Optional group from `[dev.service_groups]`; defaults to ungrouped services
+        group: Option<String>,
 
         /// Disable dependency-aware file watching and automatic restarts
         #[arg(long)]
@@ -320,4 +320,32 @@ pub enum ProjectCommands {
         #[arg(long)]
         force: bool,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn services_up_accepts_zero_or_one_group() {
+        let cli = Cli::try_parse_from(["aster", "services", "up"]).unwrap();
+        let Commands::Services {
+            command: ServicesCommands::Up { group, .. },
+        } = cli.command
+        else {
+            panic!("expected services up command");
+        };
+        assert_eq!(group, None);
+
+        let cli = Cli::try_parse_from(["aster", "services", "up", "intern"]).unwrap();
+        let Commands::Services {
+            command: ServicesCommands::Up { group, .. },
+        } = cli.command
+        else {
+            panic!("expected services up command");
+        };
+        assert_eq!(group.as_deref(), Some("intern"));
+
+        assert!(Cli::try_parse_from(["aster", "services", "up", "one", "two"]).is_err());
+    }
 }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -223,6 +223,10 @@ pub fn parse_aster_toml(path: &Path) -> Result<AsterToml> {
         toml::from_str(&content).with_context(|| format!("Failed to parse {}", path.display()))?;
 
     validate_aster_config(&config.depends_on, &config.targets, path)?;
+    config
+        .dev
+        .validate_service_groups()
+        .with_context(|| format!("Invalid service groups in {}", path.display()))?;
 
     Ok(config)
 }

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 use super::project::{validate_aster_config, TargetConfig};
@@ -52,6 +52,33 @@ pub struct DevWorkspaceConfig {
     /// Named service-to-target mappings.
     #[serde(default)]
     pub services: HashMap<String, DevServiceConfig>,
+
+    /// Named groups of services selected by `aster services up <group>`.
+    #[serde(default)]
+    pub service_groups: HashMap<String, Vec<String>>,
+}
+
+impl DevWorkspaceConfig {
+    pub(crate) fn validate_service_groups(&self) -> Result<()> {
+        for (group, services) in &self.service_groups {
+            if group.trim().is_empty() {
+                bail!("service group names cannot be empty");
+            }
+            if services.is_empty() {
+                bail!("service group '{group}' must contain at least one service");
+            }
+            let mut seen = HashSet::new();
+            for service in services {
+                if !self.services.contains_key(service) {
+                    bail!("service group '{group}' references unknown service '{service}'");
+                }
+                if !seen.insert(service) {
+                    bail!("service group '{group}' contains duplicate service '{service}'");
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 /// A named port used by one or more development services.
@@ -186,6 +213,10 @@ impl WorkspaceConfig {
             .with_context(|| format!("Failed to parse {}", config_path.display()))?;
 
         validate_aster_config(&config.depends_on, &config.targets, &config_path)?;
+        config
+            .dev
+            .validate_service_groups()
+            .with_context(|| format!("Invalid service groups in {}", config_path.display()))?;
 
         Ok(config)
     }
@@ -242,6 +273,9 @@ mod tests {
 port_env_files = [".env"]
 control_port = "api"
 
+[dev.service_groups]
+frontend = ["api"]
+
 [dev.ports.api]
 env = "API_PORT"
 file_env = "PORT"
@@ -267,6 +301,7 @@ order = 10
 
         let config = WorkspaceConfig::load(temp.path()).unwrap();
         assert_eq!(config.dev.services["api"].target, "//api:dev");
+        assert_eq!(config.dev.service_groups["frontend"], ["api"]);
         assert_eq!(
             config.dev.services["api"].open_path.as_deref(),
             Some("/health")
@@ -285,6 +320,29 @@ order = 10
         };
         assert_eq!(web.offset_from.as_deref(), Some("api"));
         assert_eq!(web.offset_base, Some(4000));
+    }
+
+    #[test]
+    fn rejects_invalid_service_groups() {
+        for (configuration, expected) in [
+            (
+                "[dev.service_groups]\nintern = [\"missing\"]\n",
+                "references unknown service 'missing'",
+            ),
+            (
+                "[dev.services.api]\ntarget = \"//api:dev\"\n[dev.service_groups]\nintern = [\"api\", \"api\"]\n",
+                "contains duplicate service 'api'",
+            ),
+            (
+                "[dev.service_groups]\nintern = []\n",
+                "must contain at least one service",
+            ),
+        ] {
+            let temp = TempDir::new().unwrap();
+            fs::write(temp.path().join("aster.toml"), configuration).unwrap();
+            let error = WorkspaceConfig::load(temp.path()).unwrap_err();
+            assert!(format!("{error:#}").contains(expected), "{error:#}");
+        }
     }
 
     #[test]

--- a/src/dev/plan.rs
+++ b/src/dev/plan.rs
@@ -32,7 +32,7 @@ pub struct ServicePlan {
 pub fn resolve_dev_plan(
     workspace_root: &Path,
     config: &DevWorkspaceConfig,
-    selected: &[String],
+    group: Option<&str>,
     projects: &[DiscoveredProject],
     graph: &TargetGraph,
     plugins: &PluginRegistry,
@@ -52,13 +52,7 @@ pub fn resolve_dev_plan(
                 .ok_or_else(|| anyhow!("control_port references unknown service port '{name}'"))
         })
         .transpose()?;
-    let selected: HashSet<&str> = selected.iter().map(String::as_str).collect();
-
-    for name in &selected {
-        if !config.services.contains_key(*name) {
-            bail!("unknown service '{name}'");
-        }
-    }
+    let selected = select_service_names(config, group)?;
 
     let project_by_address: HashMap<String, &DiscoveredProject> = projects
         .iter()
@@ -70,7 +64,7 @@ pub fn resolve_dev_plan(
 
     let mut services = Vec::new();
     for (name, service) in configured {
-        if !selected.is_empty() && !selected.contains(name.as_str()) {
+        if !selected.contains(name.as_str()) {
             continue;
         }
 
@@ -161,7 +155,10 @@ pub fn resolve_dev_plan(
     }
 
     if services.is_empty() {
-        bail!("no services selected");
+        match group {
+            Some(group) => bail!("service group '{group}' has no services"),
+            None => bail!("no services configured for the default run"),
+        }
     }
 
     Ok(DevPlan {
@@ -169,6 +166,49 @@ pub fn resolve_dev_plan(
         ports,
         control_port,
     })
+}
+
+fn select_service_names<'a>(
+    config: &'a DevWorkspaceConfig,
+    group: Option<&str>,
+) -> Result<HashSet<&'a str>> {
+    config.validate_service_groups()?;
+    if let Some(group) = group {
+        let services = config.service_groups.get(group).ok_or_else(|| {
+            let mut known = config
+                .service_groups
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>();
+            known.sort_unstable();
+            if known.is_empty() {
+                anyhow!("unknown service group '{group}'; no service groups are configured")
+            } else {
+                anyhow!(
+                    "unknown service group '{group}'; configured groups: {}",
+                    known.join(", ")
+                )
+            }
+        })?;
+        return Ok(services.iter().map(String::as_str).collect());
+    }
+
+    let grouped = config
+        .service_groups
+        .values()
+        .flatten()
+        .map(String::as_str)
+        .collect::<HashSet<_>>();
+    let mut selected = config
+        .services
+        .keys()
+        .map(String::as_str)
+        .filter(|service| !grouped.contains(service))
+        .collect::<HashSet<_>>();
+    if let Some(main) = config.service_groups.get("main") {
+        selected.extend(main.iter().map(String::as_str));
+    }
+    Ok(selected)
 }
 
 /// Resolve the named development ports without requiring service targets.
@@ -368,7 +408,80 @@ fn expand_template(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::ResolvedDevPortConfig;
+    use crate::config::{DevServiceConfig, ResolvedDevPortConfig};
+
+    fn service(target: &str) -> DevServiceConfig {
+        DevServiceConfig {
+            target: target.to_string(),
+            port: None,
+            open_path: None,
+            env_files: Vec::new(),
+            env: HashMap::new(),
+            inherit_env: Vec::new(),
+            order: 0,
+        }
+    }
+
+    #[test]
+    fn service_groups_select_grouped_or_ungrouped_services() {
+        let config = DevWorkspaceConfig {
+            services: HashMap::from([
+                ("platform".to_string(), service("//platform:dev")),
+                ("metrics".to_string(), service("//metrics:dev")),
+                ("intern-data".to_string(), service("//intern-data:dev")),
+                ("intern-fe".to_string(), service("//intern-fe:dev")),
+            ]),
+            service_groups: HashMap::from([
+                ("main".to_string(), vec!["platform".to_string()]),
+                (
+                    "intern".to_string(),
+                    vec!["intern-data".to_string(), "intern-fe".to_string()],
+                ),
+            ]),
+            ..DevWorkspaceConfig::default()
+        };
+
+        assert_eq!(
+            select_service_names(&config, None).unwrap(),
+            HashSet::from(["platform", "metrics"])
+        );
+        assert_eq!(
+            select_service_names(&config, Some("intern")).unwrap(),
+            HashSet::from(["intern-data", "intern-fe"])
+        );
+        assert_eq!(
+            select_service_names(&config, Some("main")).unwrap(),
+            HashSet::from(["platform"])
+        );
+        let error = select_service_names(&config, Some("missing")).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("configured groups: intern, main"));
+    }
+
+    #[test]
+    fn services_can_belong_to_multiple_groups() {
+        let config = DevWorkspaceConfig {
+            services: HashMap::from([
+                ("shared".to_string(), service("//shared:dev")),
+                ("one".to_string(), service("//one:dev")),
+            ]),
+            service_groups: HashMap::from([
+                ("small".to_string(), vec!["shared".to_string()]),
+                (
+                    "full".to_string(),
+                    vec!["shared".to_string(), "one".to_string()],
+                ),
+            ]),
+            ..DevWorkspaceConfig::default()
+        };
+
+        assert!(select_service_names(&config, None).unwrap().is_empty());
+        assert_eq!(
+            select_service_names(&config, Some("small")).unwrap(),
+            HashSet::from(["shared"])
+        );
+    }
 
     #[test]
     fn resolves_offset_ports_and_templates() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -952,7 +952,7 @@ fn run() -> Result<()> {
         }
         Commands::Services { command } => match command {
             ServicesCommands::Up {
-                services,
+                group,
                 no_watch,
                 no_ui,
                 dry_run,
@@ -965,7 +965,7 @@ fn run() -> Result<()> {
                 let plan = aster::dev::resolve_dev_plan(
                     &workspace_root,
                     &workspace_config.dev,
-                    &services,
+                    group.as_deref(),
                     &projects,
                     &graph,
                     &registry,

--- a/tests/config_bug_bash.rs
+++ b/tests/config_bug_bash.rs
@@ -48,6 +48,8 @@ fn configuration_scenario_matrix() {
         Scenario { name: "resolved port many env", input: "[dev.ports.http]\nenv = [\"PORT\", \"HTTP_PORT\"]\nfile_env = []\ndefault = 4000\n", expected: Expected::Accept },
         Scenario { name: "derived port", input: "[dev.ports.base]\ndefault = 4000\n[dev.ports.web]\ndefault = 3000\noffset_from = \"base\"\noffset_base = 4000\nsaturating_offset = true\n", expected: Expected::Accept },
         Scenario { name: "development service", input: "[dev.services.api]\ntarget = \"//api:dev\"\nport = \"http\"\nopen_path = \"/health\"\nenv_files = [\".env\"]\nenv = { PORT = \"{port}\" }\ninherit_env = [\"PATH\"]\norder = -2147483648\n", expected: Expected::Accept },
+        Scenario { name: "development service group", input: "[dev.services.api]\ntarget = \"//api:dev\"\n[dev.service_groups]\ncore = [\"api\"]\n", expected: Expected::Accept },
+        Scenario { name: "unknown grouped service", input: "[dev.service_groups]\ncore = [\"missing\"]\n", expected: Expected::Reject },
         Scenario { name: "cache configuration", input: "[targets.build]\ncommand = \"cargo build\"\n[targets.build.cache]\nenabled = true\ninclude = [\"src/**\"]\nexclude = [\"**/*.tmp\"]\nenv = [\"RUSTFLAGS\"]\noutputs = [\"target/debug/app\"]\n", expected: Expected::Accept },
         Scenario { name: "quoted dotted target", input: "[targets.\"check:all\"]\ncommand = \"true\"\n", expected: Expected::Accept },
         Scenario { name: "literal multiline command", input: "[targets.run]\ncommand = '''printf 'one\\ntwo' '''\n", expected: Expected::Accept },

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -563,3 +563,77 @@ stream = true
     assert_eq!(occurrences(&events, "LATER_SIDE_EFFECT"), 0);
     assert!(!token_path.exists());
 }
+
+#[test]
+fn services_up_selects_an_optional_service_group() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    fs::create_dir(root.join(".git")).unwrap();
+
+    for project in ["platform", "intern-data", "intern-fe"] {
+        let directory = root.join(project);
+        fs::create_dir(&directory).unwrap();
+        fs::write(
+            directory.join("package.json"),
+            format!(r#"{{"name":"{project}"}}"#),
+        )
+        .unwrap();
+        fs::write(
+            directory.join("aster.toml"),
+            "[targets.dev]\ncommand = \"sh -c true\"\nstream = true\n",
+        )
+        .unwrap();
+    }
+
+    fs::write(
+        root.join("aster.toml"),
+        r#"
+[dev.service_groups]
+main = ["platform"]
+intern = ["intern-data", "intern-fe"]
+
+[dev.services.platform]
+target = "//platform:dev"
+
+[dev.services.intern-data]
+target = "//intern-data:dev"
+
+[dev.services.intern-fe]
+target = "//intern-fe:dev"
+"#,
+    )
+    .unwrap();
+
+    let ungrouped = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "up", "--dry-run"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(ungrouped.status.success(), "{ungrouped:?}");
+    let stderr = String::from_utf8_lossy(&ungrouped.stderr);
+    assert!(stderr.contains("platform -> //platform:dev"), "{stderr}");
+    assert!(!stderr.contains("intern-data ->"), "{stderr}");
+    assert!(!stderr.contains("intern-fe ->"), "{stderr}");
+
+    let intern = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "up", "intern", "--dry-run"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(intern.status.success(), "{intern:?}");
+    let stderr = String::from_utf8_lossy(&intern.stderr);
+    assert!(!stderr.contains("platform ->"), "{stderr}");
+    assert!(
+        stderr.contains("intern-data -> //intern-data:dev"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("intern-fe -> //intern-fe:dev"), "{stderr}");
+
+    let missing = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "up", "missing", "--dry-run"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(!missing.status.success());
+    assert!(String::from_utf8_lossy(&missing.stderr).contains("unknown service group 'missing'"));
+}


### PR DESCRIPTION
## Summary

- add root-level `[dev.service_groups]` configuration mapping group names to existing services
- accept an optional group in `aster services up <group>`
- run the `main` group plus ungrouped services when no group is supplied
- retain the existing all-services default when no groups are configured
- validate unknown services, duplicate members, empty groups, and unknown group arguments

## Example

```toml
[dev.service_groups]
main = ["platform", "developer-portal"]
intern = ["intern-data", "intern-fe"]
```

## Validation

- `cargo test --all-features` (full suite before rebase)
- targeted group selection and real CLI dry-run integration tests after rebase
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --check`