### PR TITLE
feat: add service log viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,16 @@ aster services up --dry-run
 Service stdout, stderr, and Aster lifecycle messages are also persisted to
 `.aster/logs/<worktree>/<service>/logs.txt` in the workspace. Each service log
 is capped at 10 MiB; Aster truncates it and continues writing when it reaches
-the limit.
+the limit. Read one through the system pager from a terminal, or emit raw text
+when piping or redirecting:
+
+```console
+aster services logs platform-backend
+aster services logs platform-backend | grep ERROR
+aster services logs platform-backend > platform-backend.log
+```
+
+Interactive output honors `$PAGER`, then falls back to `less` or `more`.
 
 Clear stale or orphaned processes from development ports before starting the
 stack again:

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -275,6 +275,12 @@ pub enum ServicesCommands {
         dry_run: bool,
     },
 
+    /// Read the durable log for a configured service
+    Logs {
+        /// Service name from `[dev.services]`
+        service: String,
+    },
+
     /// Terminate processes listening on configured or specified ports
     KillPorts {
         /// Port numbers or names from `[dev.ports]` (defaults to all configured ports)
@@ -347,5 +353,20 @@ mod tests {
         assert_eq!(group.as_deref(), Some("intern"));
 
         assert!(Cli::try_parse_from(["aster", "services", "up", "one", "two"]).is_err());
+    }
+
+    #[test]
+    fn services_logs_requires_exactly_one_service() {
+        let cli = Cli::try_parse_from(["aster", "services", "logs", "api"]).unwrap();
+        let Commands::Services {
+            command: ServicesCommands::Logs { service },
+        } = cli.command
+        else {
+            panic!("expected services logs command");
+        };
+        assert_eq!(service, "api");
+
+        assert!(Cli::try_parse_from(["aster", "services", "logs"]).is_err());
+        assert!(Cli::try_parse_from(["aster", "services", "logs", "api", "web"]).is_err());
     }
 }

--- a/src/dev/log_files.rs
+++ b/src/dev/log_files.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 
 use super::plan::ServicePlan;
 use super::process::LogEvent;
+use crate::config::DevWorkspaceConfig;
 
 pub const SERVICE_LOG_MAX_BYTES: u64 = 10 * 1024 * 1024;
 const TRUNCATION_NOTICE: &str = "[aster] log truncated after reaching the 10 MiB limit\n";
@@ -31,15 +33,10 @@ impl ServiceLogFiles {
         services: impl IntoIterator<Item = &'a str>,
         max_bytes: u64,
     ) -> Result<Self> {
-        let worktree = workspace_root
-            .file_name()
-            .and_then(|name| name.to_str())
-            .filter(|name| !name.is_empty())
-            .unwrap_or("default");
         let base = workspace_root
             .join(".aster")
             .join("logs")
-            .join(encode_path_component(worktree));
+            .join(encode_path_component(worktree_name(workspace_root)));
         let mut files = HashMap::new();
 
         for service in services {
@@ -62,6 +59,121 @@ impl ServiceLogFiles {
             let _ = file.write_line(&event.line);
         }
     }
+}
+
+/// Print a configured service's durable log, paging only for an interactive terminal.
+pub fn show_service_logs(
+    workspace_root: &Path,
+    config: &DevWorkspaceConfig,
+    service: &str,
+) -> Result<()> {
+    if !config.services.contains_key(service) {
+        let mut available = config
+            .services
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        available.sort_unstable();
+        if available.is_empty() {
+            bail!("unknown service '{service}'; no services are configured");
+        }
+        bail!(
+            "unknown service '{service}'; configured services: {}",
+            available.join(", ")
+        );
+    }
+
+    let path = service_log_path(workspace_root, service);
+    let file = match File::open(&path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => bail!(
+            "no logs found for service '{service}' at {}; run `aster services up` first",
+            path.display()
+        ),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to open service log {}", path.display()));
+        }
+    };
+
+    if !io::stdout().is_terminal() {
+        return copy_to_stdout(&file);
+    }
+
+    show_in_pager(&file)
+}
+
+fn service_log_path(workspace_root: &Path, service: &str) -> PathBuf {
+    workspace_root
+        .join(".aster")
+        .join("logs")
+        .join(encode_path_component(worktree_name(workspace_root)))
+        .join(encode_path_component(service))
+        .join("logs.txt")
+}
+
+fn worktree_name(workspace_root: &Path) -> &str {
+    workspace_root
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("default")
+}
+
+fn show_in_pager(file: &File) -> Result<()> {
+    if let Some(pager) = std::env::var_os("PAGER").filter(|value| !value.is_empty()) {
+        let pager = pager
+            .to_str()
+            .ok_or_else(|| anyhow!("PAGER is not valid UTF-8"))?;
+        let command = shell_words::split(pager).context("failed to parse PAGER")?;
+        if command.is_empty() {
+            return copy_to_stdout(file);
+        }
+        let command = command.iter().map(String::as_str).collect::<Vec<_>>();
+        return run_pager(file, &command).with_context(|| format!("failed to run PAGER '{pager}'"));
+    }
+
+    #[cfg(windows)]
+    let defaults: &[&[&str]] = &[&["more.com"]];
+    #[cfg(not(windows))]
+    let defaults: &[&[&str]] = &[&["less"], &["more"]];
+
+    for command in defaults {
+        match run_pager(file, command) {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if error
+                    .downcast_ref::<io::Error>()
+                    .is_some_and(|error| error.kind() == io::ErrorKind::NotFound) =>
+            {
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    copy_to_stdout(file)
+}
+
+fn run_pager(file: &File, command: &[&str]) -> Result<()> {
+    let (program, args) = command
+        .split_first()
+        .ok_or_else(|| anyhow!("pager command is empty"))?;
+    let status = Command::new(program)
+        .args(args)
+        .stdin(Stdio::from(file.try_clone()?))
+        .status()?;
+    if !status.success() {
+        bail!("pager '{program}' exited with {status}");
+    }
+    Ok(())
+}
+
+fn copy_to_stdout(file: &File) -> Result<()> {
+    let mut stdout = io::stdout().lock();
+    let mut input = file;
+    io::copy(&mut input, &mut stdout).context("failed to write service logs to stdout")?;
+    Ok(())
 }
 
 struct CappedLogFile {

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -7,6 +7,7 @@ mod port_cleanup;
 mod process;
 mod runner;
 
+pub use log_files::show_service_logs;
 pub use plan::{resolve_dev_plan, resolve_dev_ports, DevPlan, ServicePlan};
 pub use port_cleanup::{kill_ports, resolve_port_selection, KillPortsOptions};
 pub use runner::{run_dev, DevOptions};

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,15 @@ fn run() -> Result<()> {
         "Not in an aster workspace (no aster.toml or .git found). Run 'aster init' to create one.",
     )?;
 
+    // Reading existing logs does not require project discovery or graph validation.
+    if let Commands::Services {
+        command: ServicesCommands::Logs { service },
+    } = &cli.command
+    {
+        let workspace_config = WorkspaceConfig::load(&workspace_root)?;
+        return aster::dev::show_service_logs(&workspace_root, &workspace_config.dev, service);
+    }
+
     if output_mode == OutputMode::Verbose {
         eprintln!("[aster] Workspace root: {}", workspace_root.display());
     }
@@ -991,6 +1000,7 @@ fn run() -> Result<()> {
                 let selected = aster::dev::resolve_port_selection(&configured, &ports)?;
                 aster::dev::kill_ports(&selected, aster::dev::KillPortsOptions { dry_run })?;
             }
+            ServicesCommands::Logs { .. } => unreachable!("service logs handled before discovery"),
         },
         Commands::RunTarget { ref args } | Commands::ExternalTarget(ref args) => {
             // Parse external subcommand args

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -637,3 +637,59 @@ target = "//intern-fe:dev"
     assert!(!missing.status.success());
     assert!(String::from_utf8_lossy(&missing.stderr).contains("unknown service group 'missing'"));
 }
+
+#[test]
+fn services_logs_writes_raw_log_text_when_stdout_is_piped() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::write(
+        root.join("aster.toml"),
+        "[dev.services.api]\ntarget = \"//api:dev\"\n",
+    )
+    .unwrap();
+    let log = root
+        .join(".aster/logs")
+        .join(root.file_name().unwrap())
+        .join("api/logs.txt");
+    fs::create_dir_all(log.parent().unwrap()).unwrap();
+    fs::write(&log, "ready\nERROR exploded\n").unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "logs", "api"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(output.stdout, b"ready\nERROR exploded\n");
+    assert!(output.stderr.is_empty(), "{output:?}");
+}
+
+#[test]
+fn services_logs_rejects_unknown_services_and_missing_logs() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::write(
+        root.join("aster.toml"),
+        "[dev.services.api]\ntarget = \"//api:dev\"\n",
+    )
+    .unwrap();
+
+    let unknown = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "logs", "missing"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(!unknown.status.success());
+    assert!(String::from_utf8_lossy(&unknown.stderr)
+        .contains("unknown service 'missing'; configured services: api"));
+
+    let missing = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "logs", "api"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(!missing.status.success());
+    assert!(String::from_utf8_lossy(&missing.stderr).contains("no logs found for service 'api'"));
+}


### PR DESCRIPTION
## What changed

- add `aster services logs <service>`
- use `$PAGER` in interactive terminals, falling back to `less` or `more`
- write raw log bytes to stdout for pipes and redirects
- validate configured service names and report actionable missing-log errors
- document terminal, `grep`, and redirection usage

## Verification

- `rustup run 1.88.0 cargo fmt --all -- --check`
- `rustup run 1.88.0 cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run 1.88.0 cargo doc --locked --no-deps --all-features`
- `rustup run 1.88.0 cargo test --locked --all-targets --all-features` — 570 passed
- GitHub CI was green before removing the isolated version-bump commit