### PR TITLE
feat: add Markdown skills guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ aster why //services/api:test //libs/core:build
 ```
 
 Use `aster --help` and `aster <command> --help` for the complete CLI reference.
+`aster --skills` prints a workspace-independent Markdown usage guide covering
+project selection, common targets, affected runs, watching, services, logs,
+caching, and configuration. It is suitable for supplying directly to an LLM.
 
 ## Supported languages
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -10,6 +10,7 @@ use super::output::OutputMode;
 #[derive(Parser)]
 #[command(name = "aster")]
 #[command(version, about, long_about = None)]
+#[command(arg_required_else_help = true)]
 #[command(after_help = r#"RUNNING TARGETS:
   Run any target (test, build, lint, etc.) on your projects:
 
@@ -52,7 +53,11 @@ HETEROGENEOUS RUNS:
     aster run //a:test //b:test --no-deps   # Run without unlisted dependencies"#)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Option<Commands>,
+
+    /// Print a Markdown guide for using Aster, including examples for LLMs
+    #[arg(long, global = true, exclusive = true)]
+    pub skills: bool,
 
     /// Enable verbose output
     #[arg(short, long, global = true, conflicts_with = "quiet")]
@@ -337,7 +342,7 @@ mod tests {
         let cli = Cli::try_parse_from(["aster", "services", "up"]).unwrap();
         let Commands::Services {
             command: ServicesCommands::Up { group, .. },
-        } = cli.command
+        } = cli.command.unwrap()
         else {
             panic!("expected services up command");
         };
@@ -346,7 +351,7 @@ mod tests {
         let cli = Cli::try_parse_from(["aster", "services", "up", "intern"]).unwrap();
         let Commands::Services {
             command: ServicesCommands::Up { group, .. },
-        } = cli.command
+        } = cli.command.unwrap()
         else {
             panic!("expected services up command");
         };
@@ -360,7 +365,7 @@ mod tests {
         let cli = Cli::try_parse_from(["aster", "services", "logs", "api"]).unwrap();
         let Commands::Services {
             command: ServicesCommands::Logs { service },
-        } = cli.command
+        } = cli.command.unwrap()
         else {
             panic!("expected services logs command");
         };
@@ -368,5 +373,14 @@ mod tests {
 
         assert!(Cli::try_parse_from(["aster", "services", "logs"]).is_err());
         assert!(Cli::try_parse_from(["aster", "services", "logs", "api", "web"]).is_err());
+    }
+
+    #[test]
+    fn skills_is_available_without_a_subcommand() {
+        let cli = Cli::try_parse_from(["aster", "--skills"]).unwrap();
+        assert!(cli.skills);
+        assert!(cli.command.is_none());
+
+        assert!(Cli::try_parse_from(["aster"]).is_err());
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@
 pub mod commands;
 pub mod output;
 pub mod run;
+mod skills;
 
 pub use commands::{CacheCommands, Cli, Commands, ProjectCommands, ServicesCommands};
 pub use output::{
@@ -12,3 +13,4 @@ pub use output::{
     GraphOutput, OutputMode, ProjectInfo, TargetResult, WhyOutput,
 };
 pub use run::{check_reserved_target, expand_selection, parse_run_args, select_projects, RunArgs};
+pub use skills::SKILLS_MARKDOWN;

--- a/src/cli/skills.md
+++ b/src/cli/skills.md
@@ -1,0 +1,302 @@
+# Using Aster
+
+This is a practical Markdown reference for Aster, a dependency-aware task runner
+and local-service supervisor for polyglot repositories. It describes commands,
+selection syntax, configuration, and output. It does not define policy for a
+human or an LLM.
+
+## Mental model
+
+Aster finds the workspace root from the repository's root `aster.toml` or Git
+root. It discovers projects from language and build markers such as
+`package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `mix.exs`, Gemfiles,
+gemspecs, Gradle builds, and Maven POMs. A project address is workspace-relative:
+
+- `//services/api` is a project.
+- `//services/api:test` is one target in that project.
+- `//self:test` refers to a target in the project containing the current
+  `aster.toml`.
+
+Targets such as `deps`, `build`, `test`, `lint`, `format`, `typecheck`, `dev`,
+and `clean` come from detected tooling or explicit `aster.toml` configuration.
+Aster builds a target graph, runs prerequisites first, parallelizes independent
+work, and caches eligible successful results.
+
+## Inspect a workspace before running work
+
+```console
+aster list
+aster list --json
+aster graph
+aster graph //services/api:test
+aster why //services/api:test //libs/core:build
+```
+
+`list` shows discovered projects, languages, build systems, and targets.
+`graph` shows dependencies. `why` explains a dependency path between two target
+addresses. `--json` provides structured output where supported.
+
+## Select projects
+
+Selection syntax is shared by ordinary target commands:
+
+```text
+//services/api       one exact project
+//services/...       every project below a path
+//...                every project in the workspace
+./...                every project below the current directory
+.                    the project containing the current directory
+-//vendor/...        exclude a project subtree
+```
+
+Examples:
+
+```console
+aster test //services/api
+aster test //services/...
+aster test ./...
+aster test --all
+aster test //... -//vendor/...
+aster lint --all --lang rust,nodejs
+```
+
+Dependencies are included by default. `--no-deps` limits execution to the
+selected projects. `--dependents` also includes projects that depend on the
+selection.
+
+## Build, lint, format, type-check, and test
+
+Target names are invoked directly:
+
+```console
+aster build --all
+aster lint --all
+aster format --all
+aster typecheck --all
+aster test --all
+aster test //services/api --no-deps
+aster build //libs/core --dependents
+aster test --all --warnings-as-errors
+```
+
+Only projects exposing the requested target participate. A target named like a
+built-in command can be invoked through the escape hatch:
+
+```console
+aster target services //tools/example
+aster target logs //tools/example
+```
+
+Different targets can share one dependency-aware run:
+
+```console
+aster run //services/api:test //libs/core:build //tools/cli:lint
+aster run //services/api:test //libs/core:build --no-deps
+```
+
+Useful global output flags include `--verbose`, `--quiet`, `--json`,
+`--full-logs`, and `--no-cache`. Global flags can appear before or after the
+command.
+
+## Run only work affected by Git changes
+
+```console
+aster affected test --base=main
+aster affected test --base=origin/main --dependents
+aster affected lint --base=HEAD --dry-run
+aster affected test --base=main --only-affected-files
+aster affected test --base=main --warnings-as-errors
+```
+
+Affected analysis compares against the merge base of `HEAD` and `--base`, then
+adds uncommitted changes. `--head <ref>` compares committed refs explicitly.
+`--dry-run` previews selection. `--only-affected-files` narrows targets that
+declare the `files_list` capability. CI checkouts need enough Git history to
+resolve the merge base.
+
+Workspace paths can be excluded from affected analysis in root `aster.toml`:
+
+```toml
+[affected]
+ignore = ["docs/generated/**", ".agents/**"]
+```
+
+## Watch targets while editing
+
+```console
+aster watch //services/api:build
+aster watch //services/api --target test
+aster watch //services/api:dev --debounce 500ms
+aster watch //services/api:build --no-initial
+```
+
+Watch mode observes the selected targets and their transitive dependencies.
+Relevant changes rerun ordinary targets. Targets configured with `stream = true`
+stay running and restart after relevant changes.
+
+Root configuration can extend ignores, suppress generated feedback paths, and
+set the default debounce:
+
+```toml
+[watch]
+ignore = ["coverage/**"]
+suppress_paths = ["services/web/priv/static/assets/**"]
+debounce_ms = 300
+```
+
+## Run long-lived development services
+
+Services map stable names to `stream = true` targets in root `aster.toml`:
+
+```toml
+[dev.services.api]
+target = "//services/api:dev"
+port = "api"
+order = 10
+
+[dev.services.web]
+target = "//services/web:dev"
+port = "web"
+order = 20
+
+[dev.service_groups]
+main = ["api", "web"]
+intern = ["intern-postgres", "intern-api", "intern-web"]
+```
+
+Run the default stack or one named group:
+
+```console
+aster services up
+aster services up intern
+aster services up --dry-run
+aster services up --no-ui
+aster services up --no-watch
+```
+
+With no group argument, the `main` group and services absent from every group
+run. If no `main` group exists, all ungrouped services run. An explicit group
+runs exactly that group. The default terminal UI supports service tabs, search,
+scrolling, restart, wrapping, copy, and browser opening; `?` shows its controls.
+`--no-ui` emits line-oriented logs for non-interactive environments.
+
+## Read service logs and clear occupied ports
+
+Service output is persisted at
+`.aster/logs/<worktree>/<service>/logs.txt`. Each file is capped at 10 MiB.
+
+```console
+aster services logs api
+aster services logs api | grep ERROR
+aster services logs api > api.log
+```
+
+Interactive `services logs` output honors `$PAGER`, then tries `less` and
+`more`. Piped or redirected output is raw log text on stdout.
+
+Configured development ports can be inspected or cleared:
+
+```console
+aster services kill-ports --dry-run
+aster services kill-ports
+aster services kill-ports api web 4011
+```
+
+Named ports come from `[dev.ports]`. Explicit numeric ports can be inspected or
+cleared outside an Aster workspace.
+
+## Read target logs and manage the cache
+
+Ordinary completed targets have a separate execution-log store:
+
+```console
+aster logs
+aster logs //services/api:test
+```
+
+`aster logs` refers to target execution, while `aster services logs <name>`
+refers to a supervised long-lived service.
+
+```console
+aster cache status
+aster cache status //services/api:test
+aster cache clear //services/api:test
+aster cache clear
+aster test //services/api --no-cache
+```
+
+The cache memoizes successful execution. It does not restore deleted artifacts.
+Declared outputs must still exist for a cached result to be reusable.
+
+## Configure custom projects and targets
+
+`aster init` creates a workspace file. `aster project init .` creates starter
+project configuration. A project-level `aster.toml` can define dependencies,
+targets, aliases, cache inputs, outputs, and capabilities:
+
+```toml
+name = "api"
+depends_on = ["//libs/core"]
+
+[targets.lint]
+command = "npm run lint"
+
+[targets.test]
+command = "npm test -- {files}"
+depends_on = ["//self:build", "//libs/core:build"]
+capabilities = ["files_list"]
+files_glob = "**/*.test.ts"
+
+[targets.test.cache]
+enabled = true
+include = ["config/**/*.json"]
+env = ["CI"]
+outputs = ["coverage/summary.json"]
+```
+
+Target commands use shell-style quoting but execute the parsed program directly.
+Pipes, redirects, substitutions, and `&&` require an explicit shell command such
+as `sh -c 'generator | formatter > output'`. `{files}` is expanded safely only
+for targets declaring `files_list` and must occupy a standalone argument.
+
+## Common end-to-end flows
+
+Understand and validate an unfamiliar workspace:
+
+```console
+aster list --json
+aster graph //services/api:test
+aster affected test --base=main --dependents --dry-run
+aster affected test --base=main --dependents
+```
+
+Develop with a local stack and inspect a failure:
+
+```console
+aster services up
+aster services logs api | grep -i error
+aster test //services/api --full-logs
+aster logs //services/api:test
+```
+
+Run a broad local quality pass:
+
+```console
+aster format --all
+aster lint --all --warnings-as-errors
+aster typecheck --all
+aster test --all
+aster build --all
+```
+
+## More command detail
+
+```console
+aster --help
+aster <command> --help
+aster services --help
+aster services up --help
+```
+
+Help output is the exact reference for the installed Aster version. This guide
+is emitted by that same binary with `aster --skills` and requires no workspace.

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -1,0 +1,24 @@
+/// A workspace-independent Markdown reference intended for humans and LLMs.
+pub const SKILLS_MARKDOWN: &str = include_str!("skills.md");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn guide_covers_core_and_service_workflows() {
+        assert!(SKILLS_MARKDOWN.starts_with("# Using Aster\n"));
+        for example in [
+            "aster list --json",
+            "aster lint --all",
+            "aster test --all",
+            "aster affected test",
+            "aster watch",
+            "aster services up",
+            "aster services logs",
+        ] {
+            assert!(SKILLS_MARKDOWN.contains(example), "missing {example}");
+        }
+        assert!(SKILLS_MARKDOWN.ends_with('\n'));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,12 +7,13 @@ use clap::Parser;
 use console::style;
 use std::env;
 use std::fs;
+use std::io::{self, Write};
 use std::process::ExitCode;
 
 use aster::cli::{
     build_execution_output, check_reserved_target, expand_selection, output_json, parse_run_args,
     print_summary, select_projects, Cli, Commands, GraphOutput, OutputMode, ProjectCommands,
-    ProjectInfo, ServicesCommands, WhyOutput,
+    ProjectInfo, ServicesCommands, WhyOutput, SKILLS_MARKDOWN,
 };
 use aster::config::{find_workspace_root, WorkspaceConfig};
 use aster::discovery::{discover_projects, DiscoveredProject};
@@ -49,13 +50,20 @@ fn main() -> ExitCode {
 
 fn run() -> Result<()> {
     let mut cli = Cli::parse();
+    if cli.skills {
+        return print_skills();
+    }
+    let command = cli
+        .command
+        .take()
+        .expect("clap requires either --skills or a subcommand");
     let output_mode = cli.output_mode();
     let full_logs = cli.full_logs();
 
     let cwd = env::current_dir().context("Failed to get current directory")?;
 
     // Handle init command specially - it works even without an existing workspace
-    if matches!(cli.command, Commands::Init) {
+    if matches!(command, Commands::Init) {
         return handle_init(&cwd, cli.verbose);
     }
 
@@ -63,7 +71,7 @@ fn run() -> Result<()> {
     // Named/default selection still loads the workspace configuration below.
     if let Commands::Services {
         command: ServicesCommands::KillPorts { ports, dry_run },
-    } = &cli.command
+    } = &command
     {
         if !ports.is_empty() && ports.iter().all(|port| port.parse::<u16>().is_ok()) {
             let selected = aster::dev::resolve_port_selection(&HashMap::new(), ports)?;
@@ -82,7 +90,7 @@ fn run() -> Result<()> {
     // Reading existing logs does not require project discovery or graph validation.
     if let Commands::Services {
         command: ServicesCommands::Logs { service },
-    } = &cli.command
+    } = &command
     {
         let workspace_config = WorkspaceConfig::load(&workspace_root)?;
         return aster::dev::show_service_logs(&workspace_root, &workspace_config.dev, service);
@@ -103,8 +111,8 @@ fn run() -> Result<()> {
         eprintln!("[aster] Discovered {} projects", projects.len());
     }
 
-    let explicit_target = matches!(&cli.command, Commands::RunTarget { .. });
-    match cli.command {
+    let explicit_target = matches!(&command, Commands::RunTarget { .. });
+    match command {
         Commands::Init => unreachable!("Init handled above"),
         Commands::List { path, lang } => {
             validate_lang_filter(&lang)?;
@@ -1195,6 +1203,14 @@ fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn print_skills() -> Result<()> {
+    match io::stdout().lock().write_all(SKILLS_MARKDOWN.as_bytes()) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => Ok(()),
+        Err(error) => Err(error).context("Failed to write the Aster skills guide"),
+    }
 }
 
 /// Print summary for heterogeneous execution

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -485,6 +485,26 @@ fn test_not_in_workspace() {
     );
 }
 
+#[test]
+fn skills_prints_markdown_without_a_workspace() {
+    let tmp = TempDir::new().unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .arg("--skills")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "Command failed: {output:?}");
+    assert!(output.stderr.is_empty(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.starts_with("# Using Aster\n"));
+    assert!(stdout.contains("aster lint --all"));
+    assert!(stdout.contains("aster test --all"));
+    assert!(stdout.contains("aster services up"));
+    assert!(stdout.contains("aster services logs api | grep ERROR"));
+    assert!(stdout.contains("It does not define policy"));
+}
+
 // ============================================================================
 // Phase 2 Integration Tests: Language Plugins
 // ============================================================================


### PR DESCRIPTION
## What changed

- add a workspace-independent `aster --skills` global option
- print a comprehensive Markdown guide covering discovery, project selection, linting, testing, building, affected runs, watch mode, services, service logs, target logs, caching, configuration, and machine-readable output
- state explicitly that the guide describes tool usage and does not set human or LLM policy
- handle closed stdout cleanly for shell pipelines
- document the option in the README

## Verification

- `rustup run 1.88.0 cargo fmt --all -- --check`
- `rustup run 1.88.0 cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run 1.88.0 cargo doc --locked --no-deps --all-features`
- `rustup run 1.88.0 cargo test --locked --all-targets --all-features` — 573 passed
- `aster --skills` succeeds outside a workspace and emits Markdown only to stdout
- `aster --skills | head -n 1` exits cleanly