### PR TITLE
chore: release v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,7 +108,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Build orchestration for polyglot monorepos"


### PR DESCRIPTION
## What changed

- bump Aster from `0.9.0` to `0.10.0`
- release durable bounded service logs
- release optional service groups with implicit `main` selection
- release `aster services logs <service>` with pager and pipeline support
- release the workspace-independent `aster --skills` Markdown guide

## Verification

- `rustup run 1.88.0 cargo fmt --all -- --check`
- `rustup run 1.88.0 cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustup run 1.88.0 cargo doc --locked --no-deps --all-features`
- `rustup run 1.88.0 cargo test --locked --all-targets --all-features` — 573 passed
- `rustup run 1.88.0 cargo package --locked --allow-dirty` — packaged and verified `aster v0.10.0`

## Checklist

- [x] Latest feature PRs are merged and green
- [x] Package and lockfile versions match
- [x] `v0.10.0` tag and release do not exist
- [x] Rust 1.88 release checks pass locally