### PR TITLE
Add per-group service control ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,15 +355,22 @@ transitive target graph determines which project directories are watched.
 Services can be collected into named groups in the root `aster.toml`:
 
 ```toml
+[dev.ports.intern-control]
+env = "INTERN_CONTROL_PORT"
+default = 5001
+
 [dev.service_groups]
 main = ["platform", "developer-portal", "user-portal", "agent-network"]
-intern = ["intern-postgres", "intern-data", "intern-ctl", "intern-gateway", "intern-fe"]
+intern = { services = ["intern-postgres", "intern-data", "intern-ctl", "intern-gateway", "intern-fe"], control_port = "intern-control" }
 ```
 
 `aster services up intern` runs that group. With no group argument, Aster runs
 the `main` group plus services that do not appear in any group. When no `main`
 group exists, the default remains all ungrouped services. A service may belong
-to more than one group.
+to more than one group. The array form uses `[dev].control_port`. The detailed
+form can set a named `control_port`, allowing multiple groups to run concurrently
+without their control sockets conflicting. A detailed `main` group also supplies
+the control port for `aster services up` with no group argument.
 
 The dashboard uses scalable colored service tabs beside one focused log
 stream. Use `h`/`l` or click a tab to switch services, drag the divider or use

--- a/src/cli/skills.md
+++ b/src/cli/skills.md
@@ -159,9 +159,12 @@ target = "//services/web:dev"
 port = "web"
 order = 20
 
+[dev.ports.intern-control]
+default = 5001
+
 [dev.service_groups]
 main = ["api", "web"]
-intern = ["intern-postgres", "intern-api", "intern-web"]
+intern = { services = ["intern-postgres", "intern-api", "intern-web"], control_port = "intern-control" }
 ```
 
 Run the default stack or one named group:
@@ -179,6 +182,8 @@ run. If no `main` group exists, all ungrouped services run. An explicit group
 runs exactly that group. The default terminal UI supports service tabs, search,
 scrolling, restart, wrapping, copy, and browser opening; `?` shows its controls.
 `--no-ui` emits line-oriented logs for non-interactive environments.
+Array groups use the global `[dev].control_port`. A detailed group may override
+it with its own named `control_port`, so multiple groups can run concurrently.
 
 ## Read service logs and clear occupied ports
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,7 @@ pub use project::{
     TargetConfig,
 };
 pub use workspace::{
-    find_workspace_root, AffectedWorkspaceConfig, DevPortConfig, DevServiceConfig,
-    DevWorkspaceConfig, ResolvedDevPortConfig, WatchWorkspaceConfig, WorkspaceConfig,
+    find_workspace_root, AffectedWorkspaceConfig, DetailedDevServiceGroupConfig, DevPortConfig,
+    DevServiceConfig, DevServiceGroupConfig, DevWorkspaceConfig, ResolvedDevPortConfig,
+    WatchWorkspaceConfig, WorkspaceConfig,
 };

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -55,15 +55,16 @@ pub struct DevWorkspaceConfig {
 
     /// Named groups of services selected by `aster services up <group>`.
     #[serde(default)]
-    pub service_groups: HashMap<String, Vec<String>>,
+    pub service_groups: HashMap<String, DevServiceGroupConfig>,
 }
 
 impl DevWorkspaceConfig {
     pub(crate) fn validate_service_groups(&self) -> Result<()> {
-        for (group, services) in &self.service_groups {
+        for (group, group_config) in &self.service_groups {
             if group.trim().is_empty() {
                 bail!("service group names cannot be empty");
             }
+            let services = group_config.services();
             if services.is_empty() {
                 bail!("service group '{group}' must contain at least one service");
             }
@@ -76,9 +77,52 @@ impl DevWorkspaceConfig {
                     bail!("service group '{group}' contains duplicate service '{service}'");
                 }
             }
+            if let Some(control_port) = group_config.control_port() {
+                if !self.ports.contains_key(control_port) {
+                    bail!(
+                        "service group '{group}' control_port references unknown port '{control_port}'"
+                    );
+                }
+            }
         }
         Ok(())
     }
+}
+
+/// A named set of services, optionally with its own control socket port.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum DevServiceGroupConfig {
+    /// Backwards-compatible shorthand containing only service names.
+    Services(Vec<String>),
+    /// Detailed group configuration.
+    Detailed(DetailedDevServiceGroupConfig),
+}
+
+impl DevServiceGroupConfig {
+    pub(crate) fn services(&self) -> &[String] {
+        match self {
+            Self::Services(services) => services,
+            Self::Detailed(config) => &config.services,
+        }
+    }
+
+    pub(crate) fn control_port(&self) -> Option<&str> {
+        match self {
+            Self::Services(_) => None,
+            Self::Detailed(config) => config.control_port.as_deref(),
+        }
+    }
+}
+
+/// Detailed configuration for one development service group.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DetailedDevServiceGroupConfig {
+    /// Services started when this group is selected.
+    pub services: Vec<String>,
+    /// Named port overriding `[dev].control_port` for this group.
+    pub control_port: Option<String>,
 }
 
 /// A named port used by one or more development services.
@@ -275,6 +319,7 @@ control_port = "api"
 
 [dev.service_groups]
 frontend = ["api"]
+backend = { services = ["api"], control_port = "web" }
 
 [dev.ports.api]
 env = "API_PORT"
@@ -301,7 +346,11 @@ order = 10
 
         let config = WorkspaceConfig::load(temp.path()).unwrap();
         assert_eq!(config.dev.services["api"].target, "//api:dev");
-        assert_eq!(config.dev.service_groups["frontend"], ["api"]);
+        assert_eq!(config.dev.service_groups["frontend"].services(), ["api"]);
+        assert_eq!(
+            config.dev.service_groups["backend"].control_port(),
+            Some("web")
+        );
         assert_eq!(
             config.dev.services["api"].open_path.as_deref(),
             Some("/health")
@@ -336,6 +385,10 @@ order = 10
             (
                 "[dev.service_groups]\nintern = []\n",
                 "must contain at least one service",
+            ),
+            (
+                "[dev.services.api]\ntarget = \"//api:dev\"\n[dev.service_groups]\nintern = { services = [\"api\"], control_port = \"missing\" }\n",
+                "control_port references unknown port 'missing'",
             ),
         ] {
             let temp = TempDir::new().unwrap();

--- a/src/dev/plan.rs
+++ b/src/dev/plan.rs
@@ -42,9 +42,18 @@ pub fn resolve_dev_plan(
     }
 
     let ports = resolve_dev_ports(workspace_root, config)?;
-    let control_port = config
-        .control_port
-        .as_deref()
+    let group_control_port = match group {
+        Some(group) => config
+            .service_groups
+            .get(group)
+            .and_then(|config| config.control_port()),
+        None => config
+            .service_groups
+            .get("main")
+            .and_then(|config| config.control_port()),
+    };
+    let control_port = group_control_port
+        .or(config.control_port.as_deref())
         .map(|name| {
             ports
                 .get(name)
@@ -190,13 +199,13 @@ fn select_service_names<'a>(
                 )
             }
         })?;
-        return Ok(services.iter().map(String::as_str).collect());
+        return Ok(services.services().iter().map(String::as_str).collect());
     }
 
     let grouped = config
         .service_groups
         .values()
-        .flatten()
+        .flat_map(|group| group.services())
         .map(String::as_str)
         .collect::<HashSet<_>>();
     let mut selected = config
@@ -206,7 +215,7 @@ fn select_service_names<'a>(
         .filter(|service| !grouped.contains(service))
         .collect::<HashSet<_>>();
     if let Some(main) = config.service_groups.get("main") {
-        selected.extend(main.iter().map(String::as_str));
+        selected.extend(main.services().iter().map(String::as_str));
     }
     Ok(selected)
 }
@@ -408,7 +417,10 @@ fn expand_template(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{DevServiceConfig, ResolvedDevPortConfig};
+    use crate::config::{
+        DetailedDevServiceGroupConfig, DevServiceConfig, DevServiceGroupConfig,
+        ResolvedDevPortConfig,
+    };
 
     fn service(target: &str) -> DevServiceConfig {
         DevServiceConfig {
@@ -432,10 +444,16 @@ mod tests {
                 ("intern-fe".to_string(), service("//intern-fe:dev")),
             ]),
             service_groups: HashMap::from([
-                ("main".to_string(), vec!["platform".to_string()]),
+                (
+                    "main".to_string(),
+                    DevServiceGroupConfig::Services(vec!["platform".to_string()]),
+                ),
                 (
                     "intern".to_string(),
-                    vec!["intern-data".to_string(), "intern-fe".to_string()],
+                    DevServiceGroupConfig::Services(vec![
+                        "intern-data".to_string(),
+                        "intern-fe".to_string(),
+                    ]),
                 ),
             ]),
             ..DevWorkspaceConfig::default()
@@ -467,10 +485,13 @@ mod tests {
                 ("one".to_string(), service("//one:dev")),
             ]),
             service_groups: HashMap::from([
-                ("small".to_string(), vec!["shared".to_string()]),
+                (
+                    "small".to_string(),
+                    DevServiceGroupConfig::Services(vec!["shared".to_string()]),
+                ),
                 (
                     "full".to_string(),
-                    vec!["shared".to_string(), "one".to_string()],
+                    DevServiceGroupConfig::Services(vec!["shared".to_string(), "one".to_string()]),
                 ),
             ]),
             ..DevWorkspaceConfig::default()
@@ -481,6 +502,30 @@ mod tests {
             select_service_names(&config, Some("small")).unwrap(),
             HashSet::from(["shared"])
         );
+    }
+
+    #[test]
+    fn service_group_control_port_overrides_global_control_port() {
+        let config = DevWorkspaceConfig {
+            control_port: Some("global-control".to_string()),
+            ports: HashMap::from([
+                ("global-control".to_string(), DevPortConfig::Fixed(5000)),
+                ("intern-control".to_string(), DevPortConfig::Fixed(5001)),
+            ]),
+            services: HashMap::from([("api".to_string(), service("//api:dev"))]),
+            service_groups: HashMap::from([(
+                "intern".to_string(),
+                DevServiceGroupConfig::Detailed(DetailedDevServiceGroupConfig {
+                    services: vec!["api".to_string()],
+                    control_port: Some("intern-control".to_string()),
+                }),
+            )]),
+            ..DevWorkspaceConfig::default()
+        };
+
+        let ports = resolve_ports(&config.ports, &HashMap::new()).unwrap();
+        let selected = config.service_groups["intern"].control_port();
+        assert_eq!(selected.and_then(|name| ports.get(name)), Some(&5001));
     }
 
     #[test]

--- a/tests/config_bug_bash.rs
+++ b/tests/config_bug_bash.rs
@@ -49,6 +49,7 @@ fn configuration_scenario_matrix() {
         Scenario { name: "derived port", input: "[dev.ports.base]\ndefault = 4000\n[dev.ports.web]\ndefault = 3000\noffset_from = \"base\"\noffset_base = 4000\nsaturating_offset = true\n", expected: Expected::Accept },
         Scenario { name: "development service", input: "[dev.services.api]\ntarget = \"//api:dev\"\nport = \"http\"\nopen_path = \"/health\"\nenv_files = [\".env\"]\nenv = { PORT = \"{port}\" }\ninherit_env = [\"PATH\"]\norder = -2147483648\n", expected: Expected::Accept },
         Scenario { name: "development service group", input: "[dev.services.api]\ntarget = \"//api:dev\"\n[dev.service_groups]\ncore = [\"api\"]\n", expected: Expected::Accept },
+        Scenario { name: "development service group with control port", input: "[dev.ports]\ncore_control = 5001\n[dev.services.api]\ntarget = \"//api:dev\"\n[dev.service_groups]\ncore = { services = [\"api\"], control_port = \"core_control\" }\n", expected: Expected::Accept },
         Scenario { name: "unknown grouped service", input: "[dev.service_groups]\ncore = [\"missing\"]\n", expected: Expected::Reject },
         Scenario { name: "cache configuration", input: "[targets.build]\ncommand = \"cargo build\"\n[targets.build.cache]\nenabled = true\ninclude = [\"src/**\"]\nexclude = [\"**/*.tmp\"]\nenv = [\"RUSTFLAGS\"]\noutputs = [\"target/debug/app\"]\n", expected: Expected::Accept },
         Scenario { name: "quoted dotted target", input: "[targets.\"check:all\"]\ncommand = \"true\"\n", expected: Expected::Accept },

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -588,9 +588,17 @@ fn services_up_selects_an_optional_service_group() {
     fs::write(
         root.join("aster.toml"),
         r#"
+[dev]
+control_port = "fallback-control"
+
+[dev.ports]
+fallback-control = 5100
+main-control = 5101
+intern-control = 5102
+
 [dev.service_groups]
-main = ["platform"]
-intern = ["intern-data", "intern-fe"]
+main = { services = ["platform"], control_port = "main-control" }
+intern = { services = ["intern-data", "intern-fe"], control_port = "intern-control" }
 
 [dev.services.platform]
 target = "//platform:dev"
@@ -614,6 +622,7 @@ target = "//intern-fe:dev"
     assert!(stderr.contains("platform -> //platform:dev"), "{stderr}");
     assert!(!stderr.contains("intern-data ->"), "{stderr}");
     assert!(!stderr.contains("intern-fe ->"), "{stderr}");
+    assert!(stderr.contains("control :5101"), "{stderr}");
 
     let intern = Command::new(env!("CARGO_BIN_EXE_aster"))
         .args(["services", "up", "intern", "--dry-run"])
@@ -628,6 +637,7 @@ target = "//intern-fe:dev"
         "{stderr}"
     );
     assert!(stderr.contains("intern-fe -> //intern-fe:dev"), "{stderr}");
+    assert!(stderr.contains("control :5102"), "{stderr}");
 
     let missing = Command::new(env!("CARGO_BIN_EXE_aster"))
         .args(["services", "up", "missing", "--dry-run"])
@@ -636,6 +646,90 @@ target = "//intern-fe:dev"
         .unwrap();
     assert!(!missing.status.success());
     assert!(String::from_utf8_lossy(&missing.stderr).contains("unknown service group 'missing'"));
+}
+
+#[test]
+fn concurrent_service_groups_bind_distinct_control_ports() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let alpha_reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let alpha_port = alpha_reservation.local_addr().unwrap().port();
+    let beta_reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let beta_port = beta_reservation.local_addr().unwrap().port();
+
+    fs::create_dir(root.join(".git")).unwrap();
+    for project in ["alpha", "beta"] {
+        let directory = root.join(project);
+        fs::create_dir(&directory).unwrap();
+        fs::write(
+            directory.join("package.json"),
+            format!(r#"{{"name":"{project}"}}"#),
+        )
+        .unwrap();
+        fs::write(
+            directory.join("aster.toml"),
+            "[targets.dev]\ncommand = \"sh -c 'while true; do sleep 1; done'\"\nstream = true\n",
+        )
+        .unwrap();
+    }
+    fs::write(
+        root.join("aster.toml"),
+        format!(
+            r#"
+[dev.ports]
+alpha-control = {alpha_port}
+beta-control = {beta_port}
+
+[dev.service_groups]
+alpha = {{ services = ["alpha"], control_port = "alpha-control" }}
+beta = {{ services = ["beta"], control_port = "beta-control" }}
+
+[dev.services.alpha]
+target = "//alpha:dev"
+
+[dev.services.beta]
+target = "//beta:dev"
+"#
+        ),
+    )
+    .unwrap();
+    drop(alpha_reservation);
+    drop(beta_reservation);
+
+    let mut alpha = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "up", "alpha", "--no-ui", "--no-watch"])
+        .current_dir(root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    let mut beta = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "up", "beta", "--no-ui", "--no-watch"])
+        .current_dir(root)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let (alpha_token_path, alpha_token) = wait_for_control_token(alpha_port, alpha.id());
+    let (beta_token_path, beta_token) = wait_for_control_token(beta_port, beta.id());
+    assert_eq!(
+        control_request(alpha_port, r#"{"command":"status"}"#)["ok"],
+        true
+    );
+    assert_eq!(
+        control_request(beta_port, r#"{"command":"status"}"#)["ok"],
+        true
+    );
+
+    for (port, token) in [(alpha_port, alpha_token), (beta_port, beta_token)] {
+        let request = serde_json::json!({"command": "shutdown", "token": token}).to_string();
+        assert_eq!(control_request(port, &request)["ok"], true);
+    }
+    assert!(alpha.wait().unwrap().success());
+    assert!(beta.wait().unwrap().success());
+    assert!(!alpha_token_path.exists());
+    assert!(!beta_token_path.exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- support detailed service-group configs with an optional named `control_port`
- preserve array-form groups and the global `dev.control_port` fallback
- use a detailed `main` group control port for no-argument `services up`
- document the configuration and validate unknown group control ports

## Verification

- `cargo test --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- integration test starts two service groups concurrently and exercises both control sockets