### PR TITLE
Release Aster v0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 rust-version = "1.88"
 description = "Build orchestration for polyglot monorepos"


### PR DESCRIPTION
## Summary

- bump Aster from 0.10.1 to 0.10.2
- prepare the supervised local TLS edge release

## Verification

- `cargo test --locked --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`