### PR TITLE
Add dynamic service port allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,9 +389,9 @@ port_env_files = [".env", ".env.local"]
 control_port = "control"
 
 [dev.ports.api]
-env = "API_PORT"
-file_env = "PORT"
-default = 4000
+allocation = "dynamic"
+range = [4000, 4099]
+preferred = 4000
 
 [dev.ports.web]
 env = "WEB_PORT"
@@ -409,14 +409,15 @@ target = "//services/api:dev"
 port = "api"
 open_path = "/health"
 env_files = ["services/api/.env"]
-env = { PORT = "{port}", WEB_PORT = "{ports.web}" }
+port_env = { PORT = "api", WEB_PORT = "web" }
 inherit_env = ["GOOGLE_CLOUD_MODE"]
 order = 10
 
 [dev.services.web]
 target = "//services/web:dev"
 port = "web"
-env = { PORT = "{port}", API_URL = "http://localhost:{ports.api}" }
+port_env = { PORT = "web" }
+env = { API_URL = "http://localhost:{ports.api}" }
 order = 20
 ```
 
@@ -462,7 +463,17 @@ dashboard `[open]` action uses the route's HTTPS hostname. Exact routes infer
 it from `host`. To publish an open URL for a suffix route, configure a concrete
 `open_host`; a suffix alone does not identify which tenant hostname to open.
 
-`port_env_files` participate only in named-port resolution. A service receives
+Named ports have two allocation modes. Existing integer and detailed definitions
+are static; a detailed static definition may say `allocation = "static"`
+explicitly. A dynamic root uses `allocation = "dynamic"`, an inclusive `range`,
+and an optional `preferred` candidate. Aster atomically claims the root and its
+selected derived ports, skips ports leased by another Aster supervisor or bound
+by another process, and holds the leases until the supervisor exits.
+Dynamic allocations are released automatically and are therefore excluded from
+the configured-name set used by `services kill-ports`; explicit numeric cleanup
+remains available when diagnosing a non-Aster listener.
+
+`port_env_files` participate only in static named-port resolution. A service receives
 only a small process baseline (`PATH`, home/user, temporary-directory, locale,
 shell, and terminal variables), its own `env_files`, explicit `env`,
 `ASTER_SERVICE_NAME`, and (when it has a port) `ASTER_SERVICE_PORT`; leading
@@ -475,9 +486,13 @@ service's `inherit_env` allowlist. Process environment values named by a port's
 for collision-free worktree stacks. By default, a source below the baseline is
 an error; `saturating_offset = true` clamps that delta to zero.
 
-`{port}` and `{ports.<name>}` are expanded in service target commands and
-service environment values. They are separate from the `{files}` target
-capability. `open_path` controls the dashboard's browser URL.
+`port_env = { PORT = "api" }` injects a resolved named port after service env
+files are loaded, so stale checked-in values cannot override an allocation. A
+key cannot appear in both `port_env` and `env`. `{port}` and `{ports.<name>}`
+remain available in service target commands and `env` for composite values such
+as URLs. Port references do not implicitly start services; groups remain the
+process-selection contract. These templates are separate from the `{files}`
+target capability. `open_path` controls the dashboard's browser URL.
 
 When `control_port` is configured, Aster accepts the platform launcher's
 line-delimited JSON commands on localhost: `status`, `list_services`,

--- a/docs/specs/dynamic-service-ports.html
+++ b/docs/specs/dynamic-service-ports.html
@@ -1,0 +1,265 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Aster Dynamic Service Ports</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0d12;
+      --panel: #131720;
+      --panel-2: #191f2b;
+      --text: #edf1f7;
+      --muted: #9ca8ba;
+      --line: #2b3444;
+      --accent: #86efac;
+      --accent-2: #7dd3fc;
+      --warn: #fbbf24;
+      --danger: #fb7185;
+      --code: #090b10;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background:
+        radial-gradient(circle at 90% 0%, rgba(125, 211, 252, .11), transparent 28rem),
+        radial-gradient(circle at 0% 20%, rgba(134, 239, 172, .08), transparent 24rem),
+        var(--bg);
+      color: var(--text);
+      font: 15px/1.55 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    main { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0 80px; }
+    h1, h2, h3 { line-height: 1.15; letter-spacing: -.025em; }
+    h1 { max-width: 840px; margin: 12px 0 16px; font-size: clamp(34px, 6vw, 64px); }
+    h2 { margin: 0 0 18px; font-size: 28px; }
+    h3 { margin: 0 0 8px; font-size: 17px; }
+    p { margin: 0; }
+    code { color: #d8f7e2; }
+    pre {
+      overflow-x: auto;
+      margin: 14px 0 0;
+      padding: 18px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: var(--code);
+      color: #dce7f5;
+      font: 13px/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+    .eyebrow { color: var(--accent); font-weight: 750; letter-spacing: .12em; text-transform: uppercase; }
+    .lede { max-width: 820px; color: var(--muted); font-size: 18px; }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      padding: 6px 10px;
+      border: 1px solid rgba(134, 239, 172, .35);
+      border-radius: 999px;
+      background: rgba(134, 239, 172, .08);
+      color: var(--accent);
+      font-size: 12px;
+      font-weight: 750;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+    }
+    .summary, section {
+      margin-top: 32px;
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: rgba(19, 23, 32, .94);
+      box-shadow: 0 20px 60px rgba(0, 0, 0, .2);
+    }
+    .summary { display: grid; grid-template-columns: repeat(3, 1fr); overflow: hidden; }
+    .summary > div { min-height: 132px; padding: 22px; }
+    .summary > div + div { border-left: 1px solid var(--line); }
+    .summary strong { display: block; margin-bottom: 8px; color: var(--accent-2); font-size: 19px; }
+    .summary span, .muted { color: var(--muted); }
+    section { padding: 26px; }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+    .card { padding: 18px; border: 1px solid var(--line); border-radius: 14px; background: var(--panel-2); }
+    .card.recommended { border-color: rgba(134, 239, 172, .55); box-shadow: inset 3px 0 var(--accent); }
+    .number { color: var(--accent-2); font: 750 13px ui-monospace, monospace; }
+    .tradeoff { margin-top: 10px; color: var(--muted); }
+    .decision { margin-top: 16px; padding: 16px 18px; border-left: 3px solid var(--accent); background: rgba(134, 239, 172, .07); }
+    .flow { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; margin-top: 16px; }
+    .flow div { position: relative; padding: 14px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel-2); }
+    .flow b { display: block; color: var(--accent-2); }
+    .flow small { color: var(--muted); }
+    .rules { margin: 0; padding-left: 22px; }
+    .rules li + li { margin-top: 8px; }
+    .tasks { display: grid; gap: 12px; counter-reset: task; }
+    .task { display: grid; grid-template-columns: 42px 1fr auto; gap: 12px; align-items: start; padding: 17px; border: 1px solid var(--line); border-radius: 14px; background: var(--panel-2); }
+    .task::before { counter-increment: task; content: counter(task); display: grid; place-items: center; width: 32px; height: 32px; border-radius: 9px; background: rgba(125, 211, 252, .1); color: var(--accent-2); font-weight: 800; }
+    .task p { color: var(--muted); }
+    .status { padding: 4px 8px; border: 1px solid var(--line); border-radius: 999px; color: var(--warn); font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+    .acceptance { display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px; margin-top: 14px; }
+    .check { padding: 13px 15px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel-2); }
+    .check::before { content: "✓"; margin-right: 9px; color: var(--accent); font-weight: 900; }
+    .risk { color: var(--danger); }
+    @media (max-width: 800px) {
+      main { width: min(100% - 20px, 1120px); padding-top: 28px; }
+      .summary, .grid, .acceptance { grid-template-columns: 1fr; }
+      .summary > div + div { border-left: 0; border-top: 1px solid var(--line); }
+      .flow { grid-template-columns: 1fr; }
+      .task { grid-template-columns: 38px 1fr; }
+      .status { grid-column: 2; justify-self: start; }
+    }
+  </style>
+</head>
+<body>
+<main>
+  <span class="badge">Decision spec · proposed</span>
+  <h1>Aster-owned dynamic service ports</h1>
+  <p class="lede">Allocate one collision-free port bundle per <code>aster services up</code> run, hold OS-backed leases for the supervisor lifetime, and inject the resolved values into every service without generating worktree-specific env files.</p>
+
+  <div class="summary">
+    <div><strong>DSL</strong><span>Extend named ports with <code>allocation = "dynamic"</code>; preserve every existing static form.</span></div>
+    <div><strong>Coordination</strong><span>Serialize allocation with a host-level lock and hold per-port lease locks until shutdown.</span></div>
+    <div><strong>Propagation</strong><span>Add typed <code>port_env</code> for numeric values; retain templates for composed strings and URLs.</span></div>
+  </div>
+
+  <section>
+    <h2>1. Decision options</h2>
+    <div class="grid">
+      <article class="card recommended">
+        <div class="number">OPTION 1 · RECOMMENDED</div>
+        <h3>Extend the existing named-port model</h3>
+        <p>Dynamic ports become a new resolution mode. Services continue referencing stable global port names, so current control ports, TLS routes, offsets, cleanup, and templates remain one model.</p>
+        <p class="tradeoff"><b>Tradeoff:</b> port ownership remains conventional rather than nested under a service. Cost: medium, approximately 2–4 engineering days plus FirstLanding smoke coverage.</p>
+      </article>
+      <article class="card">
+        <div class="number">OPTION 2</div>
+        <h3>Move ports under services</h3>
+        <p>Declare <code>[dev.services.platform.ports.http]</code> and reference <code>{services.platform.ports.http}</code>. Ownership is explicit, but control/TLS ports need a second model and FirstLanding requires a broad rewrite.</p>
+        <p class="tradeoff"><b>Tradeoff:</b> conceptually pure but duplicates today’s named-port graph. Cost: high, approximately 5–8 days.</p>
+      </article>
+      <article class="card">
+        <div class="number">OPTION 3</div>
+        <h3>Add first-class allocation slots</h3>
+        <p>Allocate a worktree slot and derive every port from a configured base plus offsets. This mirrors FirstLanding’s historical port bands.</p>
+        <p class="tradeoff"><b>Tradeoff:</b> compact for one monorepo, but one overlooked listener recreates the current collision class. Cost: medium, approximately 3–5 days.</p>
+      </article>
+      <article class="card">
+        <div class="number">EXEMPLAR</div>
+        <h3>FirstLanding’s atomic bundle allocator</h3>
+        <p>Reuse its strongest properties: one locked allocation transaction, complete bundles, real bind checks, and generated environment overrides.</p>
+        <p class="tradeoff"><b>Intentional deviation:</b> Aster leases ports only while the supervisor lives; it does not persist allocations for the lifetime of a Git worktree.</p>
+      </article>
+    </div>
+    <div class="decision"><b>Recommendation:</b> Option 1. The current named-port graph already expresses FirstLanding’s cross-service wiring; dynamic resolution and typed injection fill the two missing capabilities without creating a parallel port system.</div>
+  </section>
+
+  <section>
+    <h2>2. Proposed DSL</h2>
+    <pre><code># Existing forms remain static and backward compatible.
+[dev.ports.postgres]
+env = "POSTGRES_PORT"
+default = 5432
+
+# A dynamic root selects a free value from an inclusive range.
+[dev.ports.platform]
+allocation = "dynamic"
+range = [4000, 4999]
+preferred = 4000
+
+# Existing offsets form an atomic bundle with their dynamic root.
+[dev.ports.developer-portal]
+default = 3300
+offset_from = "platform"
+offset_base = 4000
+
+[dev.ports.grpc-auth]
+allocation = "dynamic"
+range = [51000, 51999]
+preferred = 51001
+
+[dev.ports.grpc-admin]
+default = 52001
+offset_from = "grpc-auth"
+offset_base = 51001
+
+[dev.services.platform]
+target = "//services/platform:dev"
+port = "platform"
+port_env = {
+  PHX_PORT = "platform",
+  GRPC_AUTH_PORT = "grpc-auth",
+  GRPC_ADMIN_PORT = "grpc-admin"
+}
+
+[dev.services.developer-portal]
+target = "//services/developer-portal:dev"
+port = "developer-portal"
+port_env = {
+  PORT = "developer-portal",
+  GRPC_AUTH_PORT = "grpc-auth"
+}
+env = {
+  PLATFORM_API_URL = "http://localhost:{ports.platform}"
+}</code></pre>
+    <div class="grid" style="margin-top:14px">
+      <div class="card"><h3>Static mode</h3><p class="muted">An integer or existing detailed definition is static. <code>allocation = "static"</code> may be accepted explicitly but is never required.</p></div>
+      <div class="card"><h3>Dynamic mode</h3><p class="muted"><code>range</code> is required; <code>preferred</code> is optional and tried first. Dynamic definitions reject <code>env</code>, <code>file_env</code>, and <code>offset_from</code>.</p></div>
+      <div class="card"><h3>Derived ports</h3><p class="muted">A static offset may depend on a dynamic root. The allocator evaluates and claims the entire transitive bundle before committing any port.</p></div>
+      <div class="card"><h3>Environment values</h3><p class="muted"><code>port_env</code> maps a variable directly to a named port. Existing <code>{port}</code> and <code>{ports.name}</code> templates remain for composite values.</p></div>
+    </div>
+  </section>
+
+  <section>
+    <h2>3. Cross-service semantics</h2>
+    <ol class="rules">
+      <li><b>Named ports are the contract.</b> Producers and consumers reference the same name; Aster does not infer ownership from target dependencies.</li>
+      <li><b><code>port_env</code> is typed.</b> Its value must be an existing named port and is injected as a decimal string after allocation. It overrides values loaded from the service’s <code>env_files</code>.</li>
+      <li><b><code>env</code> still wins over <code>env_files</code>.</b> It expands <code>{port}</code> and <code>{ports.name}</code> after allocation. A duplicate key in both <code>port_env</code> and <code>env</code> is a configuration error.</li>
+      <li><b>Selection remains explicit.</b> Referencing another service’s port does not silently start that service. Groups must continue listing the services they run.</li>
+      <li><b>Only owned listeners are claimed.</b> Claim selected services’ primary ports, their <code>port_env</code> declarations, and the selected control port. Templates and TLS upstream routes consume resolved values without claiming external listeners.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>4. Allocation lifecycle</h2>
+    <div class="flow">
+      <div><b>1 · Select</b><small>Resolve group and collect its complete named-port dependency set.</small></div>
+      <div><b>2 · Lock</b><small>Take the host-level allocator mutex shared by every local Aster process.</small></div>
+      <div><b>3 · Claim</b><small>Try candidates deterministically; exclude locked, listening, and wildcard-bound ports.</small></div>
+      <div><b>4 · Run</b><small>Hold per-port lease file handles while building the plan and supervising children.</small></div>
+      <div><b>5 · Release</b><small>Drop leases after child teardown; the OS releases leases if the supervisor crashes.</small></div>
+    </div>
+    <ol class="rules" style="margin-top:18px">
+      <li><b>Location:</b> a per-user runtime directory shared across repositories, not a worktree directory. Ports occupy a host-global namespace, so a repo-local lock is insufficient.</li>
+      <li><b>Atomicity:</b> claim static ports, dynamic roots, and derived ports as one sorted bundle while holding the allocator mutex. On any failure, release the partial bundle.</li>
+      <li><b>Crash safety:</b> one lock file per port is held for the supervisor lifetime. A stale metadata record is advisory; an unlocked lease is reclaimable. If a force-killed supervisor leaves an orphan listener, availability probes continue excluding its port.</li>
+      <li><b>Availability:</b> lock ownership prevents Aster-versus-Aster races. A loopback connect plus wildcard bind probe rejects listeners and bound sockets owned by other programs. Arbitrary services cannot eliminate the final external bind race without socket activation.</li>
+      <li><b>Restarts:</b> service restarts retain the same lease. The allocation ends only when the owning <code>services up</code> supervisor finishes.</li>
+    </ol>
+  </section>
+
+  <section>
+    <h2>5. Implementation tasks</h2>
+    <div class="tasks">
+      <article class="task"><div><h3>Configuration and validation</h3><p>Extend <code>DevPortConfig</code> with dynamic roots; add <code>port_env</code>; validate ranges, preferred values, incompatible fields, unknown references, duplicates, cycles, and overflow.</p></div><span class="status">Complete</span></article>
+      <article class="task"><div><h3>Port dependency collection</h3><p>Separate listener ownership from consumer-only templates and TLS routes so disjoint groups do not reserve external or unrelated ports.</p></div><span class="status">Complete</span></article>
+      <article class="task"><div><h3>Host allocator and lifetime leases</h3><p>Add <code>src/dev/port_allocator.rs</code> using the existing <code>fs2</code> locking dependency, deterministic candidate order, availability probes, atomic rollback, metadata, and RAII cleanup.</p></div><span class="status">Complete</span></article>
+      <article class="task"><div><h3>Plan and runner integration</h3><p>Make <code>DevPlan</code> own the lease guard; expand templates and <code>port_env</code> only after allocation; retain leases across restarts and release after process-tree shutdown.</p></div><span class="status">Complete</span></article>
+      <article class="task"><div><h3>Aster tests</h3><p>Cover static compatibility, concurrent allocators, atomic derived bundles, cleanup, env precedence, and cross-service references.</p></div><span class="status">Complete</span></article>
+      <article class="task"><div><h3>FirstLanding integration</h3><p>Convert platform, gRPC auth, scrape gRPC, and dashboard roots to dynamic ranges; keep existing derived ports; replace generated port env overrides with <code>port_env</code>; verify live and concurrent allocations.</p></div><span class="status">Complete</span></article>
+    </div>
+  </section>
+
+  <section>
+    <h2>6. Acceptance gates</h2>
+    <div class="acceptance">
+      <div class="check">Existing static configurations resolve exactly as before.</div>
+      <div class="check">Two simultaneous Aster runs cannot claim the same port.</div>
+      <div class="check">Dynamic roots and every derived port commit atomically.</div>
+      <div class="check">Normal exit and crash both make allocations reclaimable.</div>
+      <div class="check">Service env files cannot overwrite allocated <code>port_env</code> values.</div>
+      <div class="check">Consumers receive dependent named ports and composed URLs correctly.</div>
+      <div class="check">Concurrent service groups reserve only their required port closure.</div>
+      <div class="check">A live FirstLanding stack and a concurrent allocation plan receive disjoint bundles.</div>
+    </div>
+    <p class="risk" style="margin-top:18px"><b>Non-goal:</b> socket activation for arbitrary child processes. Aster guarantees conflict freedom among cooperating Aster supervisors and rejects already-bound external ports; it cannot transfer pre-bound sockets to frameworks that do not support it.</p>
+  </section>
+</main>
+</body>
+</html>

--- a/src/cli/skills.md
+++ b/src/cli/skills.md
@@ -149,14 +149,27 @@ debounce_ms = 300
 Services map stable names to `stream = true` targets in root `aster.toml`:
 
 ```toml
+[dev.ports.api]
+allocation = "dynamic"
+range = [4000, 4099]
+preferred = 4000
+
+[dev.ports.web]
+default = 3000
+offset_from = "api"
+offset_base = 4000
+
 [dev.services.api]
 target = "//services/api:dev"
 port = "api"
+port_env = { PORT = "api" }
 order = 10
 
 [dev.services.web]
 target = "//services/web:dev"
 port = "web"
+port_env = { PORT = "web" }
+env = { API_URL = "http://localhost:{ports.api}" }
 order = 20
 
 [dev.ports.intern-control]
@@ -184,6 +197,10 @@ scrolling, restart, wrapping, copy, and browser opening; `?` shows its controls.
 `--no-ui` emits line-oriented logs for non-interactive environments.
 Array groups use the global `[dev].control_port`. A detailed group may override
 it with its own named `control_port`, so multiple groups can run concurrently.
+Static ports retain their configured values. Dynamic named ports are selected
+from their ranges as one collision-free bundle per supervisor and released at
+exit. Use `port_env` for direct numeric environment values and `{ports.name}`
+inside `env` or target commands for URLs and other composite values.
 
 ## Serve trusted local HTTPS
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -8,5 +8,6 @@ pub use project::{
 pub use workspace::{
     find_workspace_root, AffectedWorkspaceConfig, DetailedDevServiceGroupConfig, DevPortConfig,
     DevServiceConfig, DevServiceGroupConfig, DevTlsProxyConfig, DevTlsRouteConfig,
-    DevWorkspaceConfig, ResolvedDevPortConfig, WatchWorkspaceConfig, WorkspaceConfig,
+    DevWorkspaceConfig, DynamicDevPortConfig, DynamicPortAllocation, ResolvedDevPortConfig,
+    StaticPortAllocation, WatchWorkspaceConfig, WorkspaceConfig,
 };

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -60,6 +60,23 @@ pub struct DevWorkspaceConfig {
 
 impl DevWorkspaceConfig {
     pub(crate) fn validate(&self) -> Result<()> {
+        for (name, port) in &self.ports {
+            if let DevPortConfig::Dynamic(port) = port {
+                let [start, end] = port.range;
+                if start == 0 || start > end {
+                    bail!(
+                        "dynamic port '{name}' range must contain valid ports in ascending order"
+                    );
+                }
+                if let Some(preferred) = port.preferred {
+                    if preferred < start || preferred > end {
+                        bail!(
+                            "dynamic port '{name}' preferred value {preferred} is outside range {start}-{end}"
+                        );
+                    }
+                }
+            }
+        }
         for (group, group_config) in &self.service_groups {
             if group.trim().is_empty() {
                 bail!("service group names cannot be empty");
@@ -86,6 +103,19 @@ impl DevWorkspaceConfig {
             }
         }
         for (name, service) in &self.services {
+            for (key, port) in &service.port_env {
+                if key.is_empty() || key.contains('=') || key.contains('\0') {
+                    bail!("service '{name}' has invalid port_env key {key:?}");
+                }
+                if service.env.contains_key(key) {
+                    bail!(
+                        "service '{name}' environment key '{key}' is configured in both env and port_env"
+                    );
+                }
+                if !self.ports.contains_key(port) {
+                    bail!("service '{name}' port_env key '{key}' references unknown port '{port}'");
+                }
+            }
             match (&service.target, &service.tls_proxy) {
                 (Some(_), None) => {}
                 (None, Some(tls)) => self.validate_tls_proxy(name, service, tls)?,
@@ -254,14 +284,43 @@ pub struct DetailedDevServiceGroupConfig {
 pub enum DevPortConfig {
     /// A fixed port.
     Fixed(u16),
+    /// A port selected and leased by Aster for one supervisor run.
+    Dynamic(DynamicDevPortConfig),
     /// A port resolved from the process environment, port env files, or a default.
     Resolved(ResolvedDevPortConfig),
+}
+
+/// Marker accepted by the backwards-compatible detailed static form.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StaticPortAllocation {
+    Static,
+}
+
+/// Marker required by a dynamic named port.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DynamicPortAllocation {
+    Dynamic,
+}
+
+/// A named port dynamically selected from an inclusive range.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DynamicDevPortConfig {
+    pub allocation: DynamicPortAllocation,
+    /// Inclusive candidate range.
+    pub range: [u16; 2],
+    /// Candidate tried before scanning the range from low to high.
+    pub preferred: Option<u16>,
 }
 
 /// Detailed named-port resolution.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ResolvedDevPortConfig {
+    /// Optional explicit declaration; omitted remains backwards-compatible static mode.
+    pub allocation: Option<StaticPortAllocation>,
     /// Process environment variables checked in order.
     #[serde(default, deserialize_with = "deserialize_one_or_many")]
     pub env: Vec<String>,
@@ -298,6 +357,10 @@ pub struct DevServiceConfig {
     /// Environment overrides. Values support `{port}` and `{ports.<name>}`.
     #[serde(default)]
     pub env: HashMap<String, String>,
+    /// Environment variables populated directly from resolved named ports.
+    /// These override env-file values and may not duplicate keys in `env`.
+    #[serde(default)]
+    pub port_env: HashMap<String, String>,
     /// Ambient environment variables explicitly allowed into the service.
     #[serde(default)]
     pub inherit_env: Vec<String>,
@@ -488,6 +551,7 @@ port = "api"
 open_path = "/health"
 env_files = ["api/.env"]
 env = { PORT = "{port}", WEB_PORT = "{ports.web}" }
+port_env = { API_PORT = "api" }
 inherit_env = ["GOOGLE_CLOUD_MODE"]
 order = 10
 "#,
@@ -512,6 +576,7 @@ order = 10
             config.dev.services["api"].inherit_env,
             ["GOOGLE_CLOUD_MODE"]
         );
+        assert_eq!(config.dev.services["api"].port_env["API_PORT"], "api");
         let DevPortConfig::Resolved(api) = &config.dev.ports["api"] else {
             panic!("expected resolved port");
         };
@@ -522,6 +587,68 @@ order = 10
         };
         assert_eq!(web.offset_from.as_deref(), Some("api"));
         assert_eq!(web.offset_base, Some(4000));
+    }
+
+    #[test]
+    fn parses_and_validates_dynamic_ports() {
+        let temp = TempDir::new().unwrap();
+        fs::write(
+            temp.path().join("aster.toml"),
+            r#"
+[dev.ports.http]
+allocation = "dynamic"
+range = [4000, 4099]
+preferred = 4001
+
+[dev.ports.database]
+allocation = "static"
+default = 5432
+
+[dev.services.web]
+target = "//web:dev"
+port = "http"
+port_env = { PORT = "http", DATABASE_PORT = "database" }
+"#,
+        )
+        .unwrap();
+
+        let config = WorkspaceConfig::load(temp.path()).unwrap();
+        let DevPortConfig::Dynamic(http) = &config.dev.ports["http"] else {
+            panic!("expected dynamic port");
+        };
+        assert_eq!(http.range, [4000, 4099]);
+        assert_eq!(http.preferred, Some(4001));
+        let DevPortConfig::Resolved(database) = &config.dev.ports["database"] else {
+            panic!("expected explicit static port");
+        };
+        assert_eq!(database.allocation, Some(StaticPortAllocation::Static));
+    }
+
+    #[test]
+    fn rejects_invalid_port_environment_references() {
+        for (configuration, expected) in [
+            (
+                "[dev.ports.http]\ndefault = 4000\n[dev.services.web]\ntarget = \"//web:dev\"\nport_env = { PORT = \"missing\" }\n",
+                "references unknown port 'missing'",
+            ),
+            (
+                "[dev.ports.http]\ndefault = 4000\n[dev.services.web]\ntarget = \"//web:dev\"\nenv = { PORT = \"4000\" }\nport_env = { PORT = \"http\" }\n",
+                "configured in both env and port_env",
+            ),
+            (
+                "[dev.ports.http]\nallocation = \"dynamic\"\nrange = [4100, 4000]\n",
+                "range must contain valid ports in ascending order",
+            ),
+            (
+                "[dev.ports.http]\nallocation = \"dynamic\"\nrange = [4000, 4099]\npreferred = 5000\n",
+                "preferred value 5000 is outside range",
+            ),
+        ] {
+            let temp = TempDir::new().unwrap();
+            fs::write(temp.path().join("aster.toml"), configuration).unwrap();
+            let error = WorkspaceConfig::load(temp.path()).unwrap_err();
+            assert!(format!("{error:#}").contains(expected), "{error:#}");
+        }
     }
 
     #[test]

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -3,13 +3,16 @@
 mod dashboard;
 mod log_files;
 mod plan;
+mod port_allocator;
 mod port_cleanup;
 mod process;
 mod runner;
 mod tls;
 
 pub use log_files::show_service_logs;
-pub use plan::{resolve_dev_plan, resolve_dev_ports, DevPlan, ServicePlan};
+pub use plan::{
+    resolve_dev_plan, resolve_dev_ports, resolve_static_dev_ports, DevPlan, ServicePlan,
+};
 pub use port_cleanup::{kill_ports, resolve_port_selection, KillPortsOptions};
 pub use runner::{run_dev, DevOptions};
 pub use tls::{serve_tls, setup_tls};

--- a/src/dev/plan.rs
+++ b/src/dev/plan.rs
@@ -679,10 +679,7 @@ fn validate_port_offsets(configs: &HashMap<String, DevPortConfig>) -> Result<()>
         }
         let mut current = name.as_str();
         let mut seen = HashSet::new();
-        loop {
-            let DevPortConfig::Resolved(current_config) = &configs[current] else {
-                break;
-            };
+        while let DevPortConfig::Resolved(current_config) = &configs[current] {
             let Some(next) = current_config.offset_from.as_deref() else {
                 break;
             };

--- a/src/dev/plan.rs
+++ b/src/dev/plan.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 
@@ -10,11 +10,14 @@ use crate::graph::TargetGraph;
 use crate::plugins::{PluginRegistry, Target};
 use crate::watch::WatchPlan;
 
+use super::port_allocator::{PortAllocator, PortLease};
+
 /// Fully resolved plan for one invocation of `aster services up`.
 pub struct DevPlan {
     pub services: Vec<ServicePlan>,
     pub ports: HashMap<String, u16>,
     pub control_port: Option<u16>,
+    _port_lease: PortLease,
 }
 
 /// One configured long-running service.
@@ -41,7 +44,7 @@ pub fn resolve_dev_plan(
         bail!("no services configured; add [dev.services.<name>] to aster.toml");
     }
 
-    let ports = resolve_dev_ports(workspace_root, config)?;
+    let selected = select_service_names(config, group)?;
     let group_control_port = match group {
         Some(group) => config
             .service_groups
@@ -52,8 +55,14 @@ pub fn resolve_dev_plan(
             .get("main")
             .and_then(|config| config.control_port()),
     };
-    let control_port = group_control_port
-        .or(config.control_port.as_deref())
+    let project_by_address: HashMap<String, &DiscoveredProject> = projects
+        .iter()
+        .map(|project| (format!("//{}", project.relative_path.display()), project))
+        .collect();
+    let selected_control_port = group_control_port.or(config.control_port.as_deref());
+    let active_ports = collect_active_ports(config, &selected, selected_control_port)?;
+    let (ports, port_lease) = allocate_dev_ports(workspace_root, config, &active_ports)?;
+    let control_port = selected_control_port
         .map(|name| {
             ports
                 .get(name)
@@ -61,13 +70,7 @@ pub fn resolve_dev_plan(
                 .ok_or_else(|| anyhow!("control_port references unknown service port '{name}'"))
         })
         .transpose()?;
-    let selected = select_service_names(config, group)?;
     let tls_open_urls = resolve_tls_open_urls(config, &selected, &ports)?;
-
-    let project_by_address: HashMap<String, &DiscoveredProject> = projects
-        .iter()
-        .map(|project| (format!("//{}", project.relative_path.display()), project))
-        .collect();
     let mut configured = config.services.iter().collect::<Vec<_>>();
     configured
         .sort_by(|(name_a, a), (name_b, b)| a.order.cmp(&b.order).then_with(|| name_a.cmp(name_b)));
@@ -100,9 +103,23 @@ pub fn resolve_dev_plan(
                 })?,
             );
         }
+        for (key, port_name) in &service.port_env {
+            let port = ports.get(port_name).ok_or_else(|| {
+                anyhow!(
+                    "service '{name}' port_env key '{key}' references unknown port '{port_name}'"
+                )
+            })?;
+            service_env.insert(key.clone(), port.to_string());
+        }
         service_env.insert("ASTER_SERVICE_NAME".to_string(), name.clone());
         if let Some(port) = port {
             service_env.insert("ASTER_SERVICE_PORT".to_string(), port.to_string());
+        }
+        if service.tls_proxy.is_some() {
+            service_env.insert(
+                "ASTER_RESOLVED_PORTS".to_string(),
+                serde_json::to_string(&ports).context("failed to encode resolved TLS ports")?,
+            );
         }
         validate_environment(name, &service_env)?;
 
@@ -210,6 +227,7 @@ pub fn resolve_dev_plan(
         services,
         ports,
         control_port,
+        _port_lease: port_lease,
     })
 }
 
@@ -297,6 +315,167 @@ fn select_service_names<'a>(
     Ok(selected)
 }
 
+fn collect_active_ports(
+    config: &DevWorkspaceConfig,
+    selected: &HashSet<&str>,
+    control_port: Option<&str>,
+) -> Result<HashSet<String>> {
+    let mut active = HashSet::new();
+    if let Some(port) = control_port {
+        active.insert(port.to_string());
+    }
+
+    for name in selected {
+        let service = &config.services[*name];
+        if let Some(port) = &service.port {
+            active.insert(port.clone());
+        }
+        active.extend(service.port_env.values().cloned());
+        // TLS routes consume upstream ports but do not own their listeners.
+        // They may intentionally point at services outside this supervisor.
+    }
+
+    // Derived ports depend on their offset source, which is part of the same
+    // atomic allocation bundle even when only the derived name is referenced.
+    let mut pending = active.iter().cloned().collect::<Vec<_>>();
+    while let Some(name) = pending.pop() {
+        let Some(DevPortConfig::Resolved(port)) = config.ports.get(&name) else {
+            continue;
+        };
+        if let Some(parent) = &port.offset_from {
+            if active.insert(parent.clone()) {
+                pending.push(parent.clone());
+            }
+        }
+    }
+    Ok(active)
+}
+
+fn allocate_dev_ports(
+    workspace_root: &Path,
+    config: &DevWorkspaceConfig,
+    active: &HashSet<String>,
+) -> Result<(HashMap<String, u16>, PortLease)> {
+    let file_env = load_env_files(workspace_root, &config.port_env_files)?;
+    validate_port_offsets(&config.ports)?;
+
+    for name in active {
+        if !config.ports.contains_key(name) {
+            bail!("selected services reference unknown port '{name}'");
+        }
+    }
+
+    let mut groups: BTreeMap<Option<String>, Vec<String>> = BTreeMap::new();
+    for name in active {
+        let root = dynamic_root(name, &config.ports)?;
+        groups.entry(root).or_default().push(name.clone());
+    }
+    for names in groups.values_mut() {
+        names.sort();
+        names.dedup();
+    }
+
+    let mut allocator = PortAllocator::lock()?;
+    // Resolution produces a complete named-port map. Seed roots that are not
+    // active in this run with deterministic display values; only active groups
+    // are probed and leased below.
+    let mut dynamic_values = config
+        .ports
+        .iter()
+        .filter_map(|(name, port)| match port {
+            DevPortConfig::Dynamic(dynamic) => {
+                Some((name.clone(), dynamic.preferred.unwrap_or(dynamic.range[0])))
+            }
+            _ => None,
+        })
+        .collect::<HashMap<_, _>>();
+
+    if let Some(static_names) = groups.remove(&None) {
+        let bundle =
+            resolve_named_bundle(&config.ports, &file_env, &dynamic_values, &static_names)?;
+        if !bundle.is_empty() && !allocator.try_bundle(workspace_root, &bundle)? {
+            bail!(
+                "configured static service ports are already allocated or listening: {}",
+                format_named_ports(&bundle)
+            );
+        }
+    }
+
+    for (root, names) in groups {
+        let root = root.expect("dynamic groups have a root");
+        let DevPortConfig::Dynamic(dynamic) = &config.ports[&root] else {
+            unreachable!("dynamic_root returns only dynamic port names");
+        };
+        let mut candidates = Vec::new();
+        if let Some(preferred) = dynamic.preferred {
+            candidates.push(preferred);
+        }
+        candidates.extend(dynamic.range[0]..=dynamic.range[1]);
+        candidates.dedup();
+
+        let mut selected = None;
+        for candidate in candidates {
+            dynamic_values.insert(root.clone(), candidate);
+            let bundle = resolve_named_bundle(&config.ports, &file_env, &dynamic_values, &names)?;
+            if allocator.try_bundle(workspace_root, &bundle)? {
+                selected = Some(candidate);
+                break;
+            }
+        }
+        let Some(value) = selected else {
+            bail!(
+                "no collision-free port bundle is available for dynamic port '{root}' in range {}-{}",
+                dynamic.range[0],
+                dynamic.range[1]
+            );
+        };
+        dynamic_values.insert(root, value);
+    }
+
+    let ports = resolve_ports(&config.ports, &file_env, &dynamic_values)?;
+    Ok((ports, allocator.finish()))
+}
+
+fn dynamic_root(name: &str, configs: &HashMap<String, DevPortConfig>) -> Result<Option<String>> {
+    let mut current = name;
+    loop {
+        match configs
+            .get(current)
+            .ok_or_else(|| anyhow!("unknown service port '{current}'"))?
+        {
+            DevPortConfig::Dynamic(_) => return Ok(Some(current.to_string())),
+            DevPortConfig::Resolved(config) => {
+                let Some(parent) = config.offset_from.as_deref() else {
+                    return Ok(None);
+                };
+                current = parent;
+            }
+            DevPortConfig::Fixed(_) => return Ok(None),
+        }
+    }
+}
+
+fn resolve_named_bundle(
+    configs: &HashMap<String, DevPortConfig>,
+    file_env: &HashMap<String, String>,
+    dynamic_values: &HashMap<String, u16>,
+    names: &[String],
+) -> Result<BTreeMap<String, u16>> {
+    let resolved = resolve_ports(configs, file_env, dynamic_values)?;
+    names
+        .iter()
+        .map(|name| Ok((name.clone(), resolved[name])))
+        .collect()
+}
+
+fn format_named_ports(ports: &BTreeMap<String, u16>) -> String {
+    ports
+        .iter()
+        .map(|(name, port)| format!("{name}={port}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Resolve the named development ports without requiring service targets.
 ///
 /// This is intentionally separate from [`resolve_dev_plan`] so maintenance
@@ -306,7 +485,34 @@ pub fn resolve_dev_ports(
     config: &DevWorkspaceConfig,
 ) -> Result<HashMap<String, u16>> {
     let port_file_env = load_env_files(workspace_root, &config.port_env_files)?;
-    resolve_ports(&config.ports, &port_file_env)
+    let dynamic_values = config
+        .ports
+        .iter()
+        .filter_map(|(name, port)| match port {
+            DevPortConfig::Dynamic(config) => {
+                Some((name.clone(), config.preferred.unwrap_or(config.range[0])))
+            }
+            _ => None,
+        })
+        .collect();
+    resolve_ports(&config.ports, &port_file_env, &dynamic_values)
+}
+
+/// Resolve only ports whose value does not depend on a dynamic allocation.
+/// Maintenance commands must not guess a dynamic run's current value.
+pub fn resolve_static_dev_ports(
+    workspace_root: &Path,
+    config: &DevWorkspaceConfig,
+) -> Result<HashMap<String, u16>> {
+    let resolved = resolve_dev_ports(workspace_root, config)?;
+    resolved
+        .into_iter()
+        .filter_map(|(name, port)| match dynamic_root(&name, &config.ports) {
+            Ok(None) => Some(Ok((name, port))),
+            Ok(Some(_)) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect()
 }
 
 fn validate_environment(service: &str, environment: &HashMap<String, String>) -> Result<()> {
@@ -366,6 +572,7 @@ fn load_env_files(workspace_root: &Path, files: &[String]) -> Result<HashMap<Str
 fn resolve_ports(
     configs: &HashMap<String, DevPortConfig>,
     file_env: &HashMap<String, String>,
+    dynamic_values: &HashMap<String, u16>,
 ) -> Result<HashMap<String, u16>> {
     validate_port_offsets(configs)?;
     let mut resolved: HashMap<String, u16> = HashMap::new();
@@ -377,6 +584,11 @@ fn resolve_ports(
             let config = &configs[name];
             let value = match config {
                 DevPortConfig::Fixed(value) => Some(*value),
+                DevPortConfig::Dynamic(_) => Some(
+                    *dynamic_values
+                        .get(name)
+                        .ok_or_else(|| anyhow!("dynamic port '{name}' has not been allocated"))?,
+                ),
                 DevPortConfig::Resolved(config) => {
                     let process_value = config
                         .env
@@ -442,6 +654,20 @@ fn resolve_ports(
 
 fn validate_port_offsets(configs: &HashMap<String, DevPortConfig>) -> Result<()> {
     for (name, config) in configs {
+        if let DevPortConfig::Dynamic(config) = config {
+            let [start, end] = config.range;
+            if start == 0 || start > end {
+                bail!("dynamic port '{name}' range must contain valid ports in ascending order");
+            }
+            if let Some(preferred) = config.preferred {
+                if preferred < start || preferred > end {
+                    bail!(
+                        "dynamic port '{name}' preferred value {preferred} is outside range {start}-{end}"
+                    );
+                }
+            }
+            continue;
+        }
         let DevPortConfig::Resolved(config) = config else {
             continue;
         };
@@ -453,7 +679,10 @@ fn validate_port_offsets(configs: &HashMap<String, DevPortConfig>) -> Result<()>
         }
         let mut current = name.as_str();
         let mut seen = HashSet::new();
-        while let DevPortConfig::Resolved(current_config) = &configs[current] {
+        loop {
+            let DevPortConfig::Resolved(current_config) = &configs[current] else {
+                break;
+            };
             let Some(next) = current_config.offset_from.as_deref() else {
                 break;
             };
@@ -507,6 +736,7 @@ mod tests {
             open_path: None,
             env_files: Vec::new(),
             env: HashMap::new(),
+            port_env: HashMap::new(),
             inherit_env: Vec::new(),
             order: 0,
         }
@@ -542,6 +772,7 @@ mod tests {
             open_path: None,
             env_files: Vec::new(),
             env: HashMap::new(),
+            port_env: HashMap::new(),
             inherit_env: Vec::new(),
             order: 0,
         };
@@ -567,7 +798,7 @@ mod tests {
             ..DevWorkspaceConfig::default()
         };
         let selected = select_service_names(&config, Some("intern")).unwrap();
-        let ports = resolve_ports(&config.ports, &HashMap::new()).unwrap();
+        let ports = resolve_ports(&config.ports, &HashMap::new(), &HashMap::new()).unwrap();
 
         let open_urls = resolve_tls_open_urls(&config, &selected, &ports).unwrap();
         assert_eq!(open_urls["frontend"], "https://intern.dev:8443");
@@ -666,7 +897,7 @@ mod tests {
             ..DevWorkspaceConfig::default()
         };
 
-        let ports = resolve_ports(&config.ports, &HashMap::new()).unwrap();
+        let ports = resolve_ports(&config.ports, &HashMap::new(), &HashMap::new()).unwrap();
         let selected = config.service_groups["intern"].control_port();
         assert_eq!(selected.and_then(|name| ports.get(name)), Some(&5001));
     }
@@ -678,6 +909,7 @@ mod tests {
             (
                 "web".to_string(),
                 DevPortConfig::Resolved(ResolvedDevPortConfig {
+                    allocation: None,
                     env: vec![],
                     file_env: None,
                     default: 3300,
@@ -687,7 +919,7 @@ mod tests {
                 }),
             ),
         ]);
-        let ports = resolve_ports(&configs, &HashMap::new()).unwrap();
+        let ports = resolve_ports(&configs, &HashMap::new(), &HashMap::new()).unwrap();
         assert_eq!(ports["web"], 3304);
         assert_eq!(
             expand_template("serve {port} --api {ports.api}", Some(3304), &ports).unwrap(),
@@ -702,6 +934,40 @@ mod tests {
     }
 
     #[test]
+    fn maintenance_resolution_excludes_dynamic_bundles() {
+        let config = DevWorkspaceConfig {
+            ports: HashMap::from([
+                (
+                    "dynamic".to_string(),
+                    DevPortConfig::Dynamic(crate::config::DynamicDevPortConfig {
+                        allocation: crate::config::DynamicPortAllocation::Dynamic,
+                        range: [4000, 4099],
+                        preferred: Some(4000),
+                    }),
+                ),
+                (
+                    "derived".to_string(),
+                    DevPortConfig::Resolved(ResolvedDevPortConfig {
+                        allocation: None,
+                        env: vec![],
+                        file_env: None,
+                        default: 3000,
+                        offset_from: Some("dynamic".to_string()),
+                        offset_base: Some(4000),
+                        saturating_offset: false,
+                    }),
+                ),
+                ("static".to_string(), DevPortConfig::Fixed(5432)),
+            ]),
+            ..DevWorkspaceConfig::default()
+        };
+        let root = tempfile::tempdir().unwrap();
+
+        let ports = resolve_static_dev_ports(root.path(), &config).unwrap();
+        assert_eq!(ports, HashMap::from([("static".to_string(), 5432)]));
+    }
+
+    #[test]
     fn rejects_invalid_derived_port_ranges() {
         for (base, default, expected) in [
             (3999, 3300, "below offset_base"),
@@ -712,6 +978,7 @@ mod tests {
                 (
                     "web".to_string(),
                     DevPortConfig::Resolved(ResolvedDevPortConfig {
+                        allocation: None,
                         env: vec![],
                         file_env: None,
                         default,
@@ -721,7 +988,7 @@ mod tests {
                     }),
                 ),
             ]);
-            let error = resolve_ports(&configs, &HashMap::new()).unwrap_err();
+            let error = resolve_ports(&configs, &HashMap::new(), &HashMap::new()).unwrap_err();
             assert!(error.to_string().contains(expected), "{error:#}");
         }
     }
@@ -729,7 +996,7 @@ mod tests {
     #[test]
     fn rejects_zero_named_port() {
         let configs = HashMap::from([("control".to_string(), DevPortConfig::Fixed(0))]);
-        let error = resolve_ports(&configs, &HashMap::new()).unwrap_err();
+        let error = resolve_ports(&configs, &HashMap::new(), &HashMap::new()).unwrap_err();
         assert!(error.to_string().contains("between 1 and 65535"));
     }
 
@@ -740,6 +1007,7 @@ mod tests {
             (
                 "web".to_string(),
                 DevPortConfig::Resolved(ResolvedDevPortConfig {
+                    allocation: None,
                     env: vec![],
                     file_env: None,
                     default: 3300,
@@ -749,7 +1017,7 @@ mod tests {
                 }),
             ),
         ]);
-        let ports = resolve_ports(&configs, &HashMap::new()).unwrap();
+        let ports = resolve_ports(&configs, &HashMap::new(), &HashMap::new()).unwrap();
         assert_eq!(ports["web"], 3300);
     }
 
@@ -759,6 +1027,7 @@ mod tests {
         let configs = HashMap::from([(
             "api".to_string(),
             DevPortConfig::Resolved(ResolvedDevPortConfig {
+                allocation: None,
                 env: vec![key.to_string()],
                 file_env: Some(vec![]),
                 default: 4100,
@@ -769,13 +1038,14 @@ mod tests {
         )]);
         let file_env = HashMap::from([(key.to_string(), "4200".to_string())]);
 
-        let ports = resolve_ports(&configs, &file_env).unwrap();
+        let ports = resolve_ports(&configs, &file_env, &HashMap::new()).unwrap();
         assert_eq!(ports["api"], 4100);
     }
 
     #[test]
     fn validates_offset_graph_before_considering_overrides() {
         let malformed = ResolvedDevPortConfig {
+            allocation: None,
             env: vec!["PORT_OVERRIDE".to_string()],
             file_env: None,
             default: 3300,
@@ -789,6 +1059,7 @@ mod tests {
 
         let cyclic = |next: &str| {
             DevPortConfig::Resolved(ResolvedDevPortConfig {
+                allocation: None,
                 env: vec![],
                 file_env: None,
                 default: 3000,

--- a/src/dev/port_allocator.rs
+++ b/src/dev/port_allocator.rs
@@ -1,0 +1,171 @@
+use std::collections::{BTreeMap, HashSet};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context, Result};
+use fs2::FileExt;
+
+/// OS-backed leases held for the lifetime of one service supervisor.
+///
+/// Dropping the files releases every lock, including when the process is
+/// terminated without running application cleanup.
+pub struct PortLease {
+    #[allow(dead_code)]
+    files: Vec<File>,
+}
+
+pub(crate) struct PortAllocator {
+    directory: PathBuf,
+    _allocation_lock: File,
+    files: Vec<File>,
+    ports: HashSet<u16>,
+}
+
+impl PortAllocator {
+    pub(crate) fn lock() -> Result<Self> {
+        let directory = lease_directory();
+        fs::create_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to create port lease directory {}",
+                directory.display()
+            )
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&directory, fs::Permissions::from_mode(0o700)).with_context(
+                || {
+                    format!(
+                        "failed to secure port lease directory {}",
+                        directory.display()
+                    )
+                },
+            )?;
+        }
+        let allocation_lock = open_lock(&directory.join("allocation.lock"))?;
+        allocation_lock
+            .lock_exclusive()
+            .context("failed to acquire the Aster port allocator lock")?;
+        Ok(Self {
+            directory,
+            _allocation_lock: allocation_lock,
+            files: Vec::new(),
+            ports: HashSet::new(),
+        })
+    }
+
+    /// Try one complete bundle. A failed candidate releases all of its locks.
+    pub(crate) fn try_bundle(
+        &mut self,
+        workspace_root: &Path,
+        ports: &BTreeMap<String, u16>,
+    ) -> Result<bool> {
+        let mut values = HashSet::new();
+        for (name, port) in ports {
+            if *port == 0 {
+                bail!("port '{name}' must be between 1 and 65535");
+            }
+            values.insert(*port);
+            if self.ports.contains(port) {
+                return Ok(false);
+            }
+        }
+
+        let mut candidate_files = Vec::new();
+        for port in values.iter().copied() {
+            let file = open_lock(&self.directory.join(format!("{port}.lock")))?;
+            if let Err(error) = file.try_lock_exclusive() {
+                if error.kind() == std::io::ErrorKind::WouldBlock {
+                    return Ok(false);
+                }
+                return Err(error)
+                    .with_context(|| format!("failed to acquire port lease for 127.0.0.1:{port}"));
+            }
+            if !port_is_available(port)? {
+                return Ok(false);
+            }
+            candidate_files.push((port, file));
+        }
+
+        // Metadata is advisory, but only committed bundles should identify
+        // themselves as owned. Failed probes leave unlocked, empty files.
+        for (_, file) in &mut candidate_files {
+            file.set_len(0)?;
+            file.seek(SeekFrom::Start(0))?;
+            writeln!(
+                file,
+                "pid={} workspace={}",
+                std::process::id(),
+                workspace_root.display()
+            )?;
+            file.sync_data()?;
+        }
+
+        self.ports.extend(values);
+        self.files
+            .extend(candidate_files.into_iter().map(|(_, file)| file));
+        Ok(true)
+    }
+
+    pub(crate) fn finish(self) -> PortLease {
+        PortLease { files: self.files }
+    }
+}
+
+fn open_lock(path: &Path) -> Result<File> {
+    OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(path)
+        .with_context(|| format!("failed to open port lock {}", path.display()))
+}
+
+fn port_is_available(port: u16) -> Result<bool> {
+    // On macOS, a listener created with SO_REUSEADDR on 0.0.0.0 can coexist
+    // with a short-lived 127.0.0.1 bind probe. Connecting first catches that
+    // listener, while the wildcard bind catches sockets that are bound but
+    // not yet listening.
+    if TcpStream::connect(("127.0.0.1", port)).is_ok() {
+        return Ok(false);
+    }
+
+    match TcpListener::bind(("0.0.0.0", port)) {
+        Ok(listener) => {
+            drop(listener);
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::AddrInUse => Ok(false),
+        Err(error) if error.kind() == std::io::ErrorKind::PermissionDenied => Ok(false),
+        Err(error) => Err(error).with_context(|| format!("failed to probe 0.0.0.0:{port}")),
+    }
+}
+
+fn lease_directory() -> PathBuf {
+    if let Some(path) = std::env::var_os("ASTER_PORT_LEASE_DIR") {
+        return PathBuf::from(path);
+    }
+    #[cfg(unix)]
+    let identity = unsafe { libc::geteuid() }.to_string();
+    #[cfg(not(unix))]
+    let identity = std::env::var("USERNAME").unwrap_or_else(|_| "user".to_string());
+    std::env::temp_dir().join(format!("aster-port-leases-v1-{identity}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn availability_probe_rejects_and_then_releases_external_listener() {
+        let listener = TcpListener::bind(("0.0.0.0", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        assert!(!port_is_available(port).unwrap());
+
+        drop(listener);
+        assert!(port_is_available(port).unwrap());
+    }
+}

--- a/src/dev/tls.rs
+++ b/src/dev/tls.rs
@@ -93,7 +93,12 @@ pub fn serve_tls(workspace_root: &Path, config: &DevWorkspaceConfig, edge: &str)
         bail!("TLS edge '{edge}' has no certificate; run `aster services tls setup {edge}`");
     }
 
-    let ports = super::resolve_dev_ports(workspace_root, config)?;
+    let ports = match std::env::var("ASTER_RESOLVED_PORTS") {
+        Ok(encoded) => serde_json::from_str(&encoded)
+            .context("ASTER_RESOLVED_PORTS is not a valid named-port map")?,
+        Err(std::env::VarError::NotPresent) => super::resolve_dev_ports(workspace_root, config)?,
+        Err(error) => return Err(error).context("failed to read ASTER_RESOLVED_PORTS"),
+    };
     let port_name = service
         .port
         .as_deref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1022,7 +1022,7 @@ fn run() -> Result<()> {
             ServicesCommands::KillPorts { ports, dry_run } => {
                 let workspace_config = WorkspaceConfig::load(&workspace_root)?;
                 let configured =
-                    aster::dev::resolve_dev_ports(&workspace_root, &workspace_config.dev)?;
+                    aster::dev::resolve_static_dev_ports(&workspace_root, &workspace_config.dev)?;
                 let selected = aster::dev::resolve_port_selection(&configured, &ports)?;
                 aster::dev::kill_ports(&selected, aster::dev::KillPortsOptions { dry_run })?;
             }

--- a/tests/config_bug_bash.rs
+++ b/tests/config_bug_bash.rs
@@ -47,6 +47,8 @@ fn configuration_scenario_matrix() {
         Scenario { name: "resolved port one env", input: "[dev.ports.http]\nenv = \"PORT\"\ndefault = 4000\n", expected: Expected::Accept },
         Scenario { name: "resolved port many env", input: "[dev.ports.http]\nenv = [\"PORT\", \"HTTP_PORT\"]\nfile_env = []\ndefault = 4000\n", expected: Expected::Accept },
         Scenario { name: "derived port", input: "[dev.ports.base]\ndefault = 4000\n[dev.ports.web]\ndefault = 3000\noffset_from = \"base\"\noffset_base = 4000\nsaturating_offset = true\n", expected: Expected::Accept },
+        Scenario { name: "dynamic port", input: "[dev.ports.http]\nallocation = \"dynamic\"\nrange = [4000, 4099]\npreferred = 4000\n", expected: Expected::Accept },
+        Scenario { name: "explicit static port", input: "[dev.ports.http]\nallocation = \"static\"\ndefault = 4000\n", expected: Expected::Accept },
         Scenario { name: "development service", input: "[dev.services.api]\ntarget = \"//api:dev\"\nport = \"http\"\nopen_path = \"/health\"\nenv_files = [\".env\"]\nenv = { PORT = \"{port}\" }\ninherit_env = [\"PATH\"]\norder = -2147483648\n", expected: Expected::Accept },
         Scenario { name: "development service group", input: "[dev.services.api]\ntarget = \"//api:dev\"\n[dev.service_groups]\ncore = [\"api\"]\n", expected: Expected::Accept },
         Scenario { name: "development service group with control port", input: "[dev.ports]\ncore_control = 5001\n[dev.services.api]\ntarget = \"//api:dev\"\n[dev.service_groups]\ncore = { services = [\"api\"], control_port = \"core_control\" }\n", expected: Expected::Accept },

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -106,6 +106,34 @@ fn wait_for_control_token(port: u16, process_id: u32) -> (std::path::PathBuf, St
     (path, token)
 }
 
+fn reserve_consecutive_dynamic_bundles() -> (u16, u16) {
+    for start in 30000u16..60000u16 {
+        let Some(derived_start) = start.checked_add(1000) else {
+            break;
+        };
+        let Some(derived_next) = derived_start.checked_add(1) else {
+            break;
+        };
+        let listeners = [start, start + 1, derived_start, derived_next]
+            .into_iter()
+            .map(|port| TcpListener::bind(("127.0.0.1", port)))
+            .collect::<Result<Vec<_>, _>>();
+        if let Ok(listeners) = listeners {
+            drop(listeners);
+            return (start, derived_start);
+        }
+    }
+    panic!("could not find two consecutive free dynamic port bundles");
+}
+
+fn terminate_aster(child: &mut std::process::Child) {
+    unsafe {
+        libc::kill(child.id() as i32, libc::SIGTERM);
+    }
+    let status = child.wait().unwrap();
+    assert_eq!(status.code(), Some(143));
+}
+
 #[test]
 fn services_kill_ports_previews_then_clears_configured_listener() {
     let temp = tempfile::tempdir().unwrap();
@@ -174,6 +202,100 @@ fn services_kill_ports_previews_then_clears_configured_listener() {
     });
     assert!(TcpStream::connect(("127.0.0.1", port)).is_err());
     assert!(String::from_utf8_lossy(&cleanup.stdout).contains("Cleared"));
+}
+
+#[test]
+fn dynamic_port_bundles_are_distinct_propagated_and_released() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let lease_dir = root.join("leases");
+    let (start, derived_start) = reserve_consecutive_dynamic_bundles();
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::create_dir(root.join("app")).unwrap();
+    fs::write(root.join("app/package.json"), r#"{"name":"app"}"#).unwrap();
+    fs::write(root.join("service.env"), "DEPENDENT_PORT=wrong\n").unwrap();
+    fs::write(
+        root.join("aster.toml"),
+        format!(
+            r#"
+[dev.ports.http]
+allocation = "dynamic"
+range = [{start}, {}]
+preferred = {start}
+
+[dev.ports.dependent]
+default = {derived_start}
+offset_from = "http"
+offset_base = {start}
+
+[dev.services.web]
+target = "//app:dev"
+port = "http"
+env_files = ["service.env"]
+port_env = {{ DEPENDENT_PORT = "dependent" }}
+"#,
+            start + 1
+        ),
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/aster.toml"),
+        r#"
+[targets.dev]
+command = "sh -c 'echo $ASTER_SERVICE_PORT:$DEPENDENT_PORT >> ../events.log; python3 -m http.server {port}'"
+stream = true
+"#,
+    )
+    .unwrap();
+
+    let launch = || {
+        Command::new(env!("CARGO_BIN_EXE_aster"))
+            .args(["services", "up", "--no-ui", "--no-watch"])
+            .current_dir(root)
+            .env("ASTER_PORT_LEASE_DIR", &lease_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap()
+    };
+
+    let events = root.join("events.log");
+    let mut first = launch();
+    wait_until(Duration::from_secs(20), || {
+        fs::read_to_string(&events)
+            .unwrap_or_default()
+            .contains(&format!("{start}:{derived_start}"))
+            && TcpStream::connect(("127.0.0.1", start)).is_ok()
+    });
+
+    let mut second = launch();
+    wait_until(Duration::from_secs(20), || {
+        fs::read_to_string(&events)
+            .unwrap_or_default()
+            .contains(&format!("{}:{}", start + 1, derived_start + 1))
+            && TcpStream::connect(("127.0.0.1", start + 1)).is_ok()
+    });
+    assert!(first.try_wait().unwrap().is_none());
+    assert!(second.try_wait().unwrap().is_none());
+
+    terminate_aster(&mut first);
+    wait_until(Duration::from_secs(5), || {
+        TcpStream::connect(("127.0.0.1", start)).is_err()
+    });
+
+    let previous = occurrences(&events, &format!("{start}:{derived_start}"));
+    let mut third = launch();
+    wait_until(Duration::from_secs(20), || {
+        occurrences(&events, &format!("{start}:{derived_start}")) > previous
+            && TcpStream::connect(("127.0.0.1", start)).is_ok()
+    });
+
+    terminate_aster(&mut third);
+    terminate_aster(&mut second);
+    wait_until(Duration::from_secs(5), || {
+        TcpStream::connect(("127.0.0.1", start)).is_err()
+            && TcpStream::connect(("127.0.0.1", start + 1)).is_err()
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add static and dynamic named-port declarations with deterministic preferred-then-range selection
- coordinate concurrent Aster supervisors with host-level allocation locking and per-port lifetime leases
- inject allocated self and dependency ports through `port_env`, including TLS resolved-port propagation
- preserve atomic offset bundles and exclude consumer-only references from listener ownership
- document the DSL and allocation lifecycle

## Validation

- `cargo test` (586 tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- live FirstLanding stack selected free ports around existing listeners
- concurrent FirstLanding plan received a disjoint bundle
- graceful shutdown released listeners and leases

## FirstLanding

Companion integration: ArchAstro/firstlanding#9949.