### PR TITLE
Recover crashed dynamic service ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,8 +331,8 @@ Clear stale or orphaned processes from development ports before starting the
 stack again:
 
 ```console
-aster services kill-ports --dry-run     # inspect every configured port
-aster services kill-ports               # clean every configured port
+aster services kill-ports --dry-run     # inspect every known worktree port
+aster services kill-ports               # clean every known worktree port
 aster services kill-ports api web 4011  # clean named and explicit ports
 ```
 
@@ -469,9 +469,11 @@ explicitly. A dynamic root uses `allocation = "dynamic"`, an inclusive `range`,
 and an optional `preferred` candidate. Aster atomically claims the root and its
 selected derived ports, skips ports leased by another Aster supervisor or bound
 by another process, and holds the leases until the supervisor exits.
-Dynamic allocations are released automatically and are therefore excluded from
-the configured-name set used by `services kill-ports`; explicit numeric cleanup
-remains available when diagnosing a non-Aster listener.
+Each supervisor also writes a worktree-scoped allocation manifest. Normal
+shutdown removes it after child teardown. If the supervisor crashes and leaves
+an orphan listener, `services kill-ports` uses the retained manifest to resolve
+dynamic names and removes it after the complete recorded bundle is free.
+Explicit numeric cleanup remains available for non-Aster listeners.
 
 `port_env_files` participate only in static named-port resolution. A service receives
 only a small process baseline (`PATH`, home/user, temporary-directory, locale,

--- a/docs/specs/dynamic-service-ports.html
+++ b/docs/specs/dynamic-service-ports.html
@@ -222,13 +222,13 @@ env = {
       <div><b>1 · Select</b><small>Resolve group and collect its complete named-port dependency set.</small></div>
       <div><b>2 · Lock</b><small>Take the host-level allocator mutex shared by every local Aster process.</small></div>
       <div><b>3 · Claim</b><small>Try candidates deterministically; exclude locked, listening, and wildcard-bound ports.</small></div>
-      <div><b>4 · Run</b><small>Hold per-port lease file handles while building the plan and supervising children.</small></div>
-      <div><b>5 · Release</b><small>Drop leases after child teardown; the OS releases leases if the supervisor crashes.</small></div>
+      <div><b>4 · Run</b><small>Hold per-port leases and a worktree-scoped allocation manifest while supervising children.</small></div>
+      <div><b>5 · Release</b><small>Remove the manifest after child teardown; retain it for orphan recovery if the supervisor crashes.</small></div>
     </div>
     <ol class="rules" style="margin-top:18px">
       <li><b>Location:</b> a per-user runtime directory shared across repositories, not a worktree directory. Ports occupy a host-global namespace, so a repo-local lock is insufficient.</li>
       <li><b>Atomicity:</b> claim static ports, dynamic roots, and derived ports as one sorted bundle while holding the allocator mutex. On any failure, release the partial bundle.</li>
-      <li><b>Crash safety:</b> one lock file per port is held for the supervisor lifetime. A stale metadata record is advisory; an unlocked lease is reclaimable. If a force-killed supervisor leaves an orphan listener, availability probes continue excluding its port.</li>
+      <li><b>Crash safety:</b> one lock file per port is held for the supervisor lifetime. The OS releases locks after a crash, while the durable allocation manifest retains the named bundle. <code>services kill-ports</code> can then discover orphan listeners by name and removes the manifest only after its bundle is unlocked and free.</li>
       <li><b>Availability:</b> lock ownership prevents Aster-versus-Aster races. A loopback connect plus wildcard bind probe rejects listeners and bound sockets owned by other programs. Arbitrary services cannot eliminate the final external bind race without socket activation.</li>
       <li><b>Restarts:</b> service restarts retain the same lease. The allocation ends only when the owning <code>services up</code> supervisor finishes.</li>
     </ol>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -288,7 +288,7 @@ pub enum ServicesCommands {
 
     /// Terminate processes listening on configured or specified ports
     KillPorts {
-        /// Port numbers or names from `[dev.ports]` (defaults to all configured ports)
+        /// Port numbers or configured/allocated names (defaults to all known workspace ports)
         ports: Vec<String>,
 
         /// Show matching processes without terminating them

--- a/src/cli/skills.md
+++ b/src/cli/skills.md
@@ -257,7 +257,8 @@ aster services kill-ports
 aster services kill-ports api web 4011
 ```
 
-Named ports come from `[dev.ports]`. Explicit numeric ports can be inspected or
+Named ports come from `[dev.ports]` and this worktree's active or crash-left
+dynamic allocation manifests. Explicit numeric ports can be inspected or
 cleared outside an Aster workspace.
 
 ## Read target logs and manage the cache

--- a/src/dev/mod.rs
+++ b/src/dev/mod.rs
@@ -13,6 +13,9 @@ pub use log_files::show_service_logs;
 pub use plan::{
     resolve_dev_plan, resolve_dev_ports, resolve_static_dev_ports, DevPlan, ServicePlan,
 };
-pub use port_cleanup::{kill_ports, resolve_port_selection, KillPortsOptions};
+pub use port_cleanup::{
+    kill_ports, kill_workspace_ports, resolve_port_selection, resolve_workspace_port_selection,
+    KillPortsOptions,
+};
 pub use runner::{run_dev, DevOptions};
 pub use tls::{serve_tls, setup_tls};

--- a/src/dev/plan.rs
+++ b/src/dev/plan.rs
@@ -433,7 +433,7 @@ fn allocate_dev_ports(
     }
 
     let ports = resolve_ports(&config.ports, &file_env, &dynamic_values)?;
-    Ok((ports, allocator.finish()))
+    Ok((ports, allocator.finish(workspace_root)?))
 }
 
 fn dynamic_root(name: &str, configs: &HashMap<String, DevPortConfig>) -> Result<Option<String>> {

--- a/src/dev/port_allocator.rs
+++ b/src/dev/port_allocator.rs
@@ -1,11 +1,13 @@
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Seek, SeekFrom, Write};
 use std::net::{TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
 use fs2::FileExt;
+use serde::{Deserialize, Serialize};
 
 /// OS-backed leases held for the lifetime of one service supervisor.
 ///
@@ -14,6 +16,13 @@ use fs2::FileExt;
 pub struct PortLease {
     #[allow(dead_code)]
     files: Vec<File>,
+    manifest_path: PathBuf,
+}
+
+impl Drop for PortLease {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.manifest_path);
+    }
 }
 
 pub(crate) struct PortAllocator {
@@ -21,6 +30,15 @@ pub(crate) struct PortAllocator {
     _allocation_lock: File,
     files: Vec<File>,
     ports: HashSet<u16>,
+    named_ports: BTreeMap<String, u16>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct AllocationManifest {
+    version: u8,
+    supervisor_pid: u32,
+    workspace_root: String,
+    ports: BTreeMap<String, u16>,
 }
 
 impl PortAllocator {
@@ -53,6 +71,7 @@ impl PortAllocator {
             _allocation_lock: allocation_lock,
             files: Vec::new(),
             ports: HashSet::new(),
+            named_ports: BTreeMap::new(),
         })
     }
 
@@ -104,14 +123,169 @@ impl PortAllocator {
         }
 
         self.ports.extend(values);
+        self.named_ports.extend(ports.clone());
         self.files
             .extend(candidate_files.into_iter().map(|(_, file)| file));
         Ok(true)
     }
 
-    pub(crate) fn finish(self) -> PortLease {
-        PortLease { files: self.files }
+    pub(crate) fn finish(self, workspace_root: &Path) -> Result<PortLease> {
+        let manifest = AllocationManifest {
+            version: 1,
+            supervisor_pid: std::process::id(),
+            workspace_root: canonical_workspace(workspace_root)?,
+            ports: self.named_ports,
+        };
+        let manifest_path = write_manifest(&self.directory, &manifest)?;
+        Ok(PortLease {
+            files: self.files,
+            manifest_path,
+        })
     }
+}
+
+pub(crate) fn workspace_allocated_ports(
+    workspace_root: &Path,
+) -> Result<HashMap<String, BTreeSet<u16>>> {
+    let workspace_root = canonical_workspace(workspace_root)?;
+    let mut ports = HashMap::<String, BTreeSet<u16>>::new();
+    for (_, manifest) in workspace_manifests(&workspace_root)? {
+        for (name, port) in manifest.ports {
+            ports.entry(name).or_default().insert(port);
+        }
+    }
+    Ok(ports)
+}
+
+/// Remove crash-left manifests only after every recorded lease is unlocked and
+/// every recorded port is free. Active supervisors retain their manifests.
+pub(crate) fn prune_workspace_manifests(workspace_root: &Path) -> Result<()> {
+    let workspace_root = canonical_workspace(workspace_root)?;
+    let directory = lease_directory();
+    if !directory.exists() {
+        return Ok(());
+    }
+    let allocation_lock = open_lock(&directory.join("allocation.lock"))?;
+    allocation_lock
+        .lock_exclusive()
+        .context("failed to acquire the Aster port allocator lock")?;
+    for (path, manifest) in workspace_manifests(&workspace_root)? {
+        let mut leased = false;
+        for port in manifest.ports.values().copied().collect::<HashSet<_>>() {
+            let file = open_lock(&directory.join(format!("{port}.lock")))?;
+            match file.try_lock_exclusive() {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    leased = true;
+                    break;
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("failed to inspect port lease for {port}"));
+                }
+            }
+        }
+        let mut all_available = true;
+        if !leased {
+            for port in manifest.ports.values().copied() {
+                if !port_is_available(port)? {
+                    all_available = false;
+                    break;
+                }
+            }
+        }
+        if !leased && all_available {
+            fs::remove_file(&path).with_context(|| {
+                format!(
+                    "failed to remove stale allocation manifest {}",
+                    path.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn write_manifest(directory: &Path, manifest: &AllocationManifest) -> Result<PathBuf> {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_nanos();
+    for suffix in 0..100_u8 {
+        let stem = format!(
+            "allocation-{}-{timestamp}-{suffix}",
+            manifest.supervisor_pid
+        );
+        let temporary = directory.join(format!(".{stem}.tmp"));
+        let path = directory.join(format!("{stem}.json"));
+        let mut file = match OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error).context("failed to create allocation manifest"),
+        };
+        serde_json::to_writer_pretty(&mut file, manifest)
+            .context("failed to encode allocation manifest")?;
+        writeln!(file)?;
+        file.sync_all()?;
+        fs::rename(&temporary, &path)
+            .with_context(|| format!("failed to publish allocation manifest {}", path.display()))?;
+        return Ok(path);
+    }
+    bail!("failed to choose a unique allocation manifest name")
+}
+
+fn workspace_manifests(workspace_root: &str) -> Result<Vec<(PathBuf, AllocationManifest)>> {
+    let directory = lease_directory();
+    let entries = match fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to read port lease directory {}",
+                    directory.display()
+                )
+            });
+        }
+    };
+    let mut manifests = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("allocation-")
+            || path.extension().and_then(|value| value.to_str()) != Some("json")
+        {
+            continue;
+        }
+        let file = File::open(&path)
+            .with_context(|| format!("failed to open allocation manifest {}", path.display()))?;
+        let manifest: AllocationManifest = serde_json::from_reader(file)
+            .with_context(|| format!("failed to parse allocation manifest {}", path.display()))?;
+        if manifest.version == 1 && manifest.workspace_root == workspace_root {
+            manifests.push((path, manifest));
+        }
+    }
+    Ok(manifests)
+}
+
+fn canonical_workspace(workspace_root: &Path) -> Result<String> {
+    Ok(workspace_root
+        .canonicalize()
+        .with_context(|| {
+            format!(
+                "failed to canonicalize workspace root {}",
+                workspace_root.display()
+            )
+        })?
+        .to_string_lossy()
+        .into_owned())
 }
 
 fn open_lock(path: &Path) -> Result<File> {

--- a/src/dev/port_cleanup.rs
+++ b/src/dev/port_cleanup.rs
@@ -1,9 +1,12 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::Path;
 use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
+
+use super::port_allocator::{prune_workspace_manifests, workspace_allocated_ports};
 
 const TERMINATE_GRACE: Duration = Duration::from_secs(2);
 
@@ -45,6 +48,61 @@ pub fn resolve_port_selection(
         bail!("no ports selected; configure [dev.ports] or provide port numbers");
     }
     Ok(selected.into_iter().collect())
+}
+
+/// Resolve configured static ports plus every allocation recorded for this
+/// worktree. A dynamic name can map to multiple concurrent supervisors.
+pub fn resolve_workspace_port_selection(
+    workspace_root: &Path,
+    configured: &HashMap<String, u16>,
+    requested: &[String],
+) -> Result<Vec<u16>> {
+    let allocated = workspace_allocated_ports(workspace_root)?;
+    let mut selected = BTreeSet::new();
+    if requested.is_empty() {
+        selected.extend(configured.values().copied());
+        selected.extend(allocated.values().flatten().copied());
+    } else {
+        for value in requested {
+            let mut matched = false;
+            if let Some(port) = configured.get(value) {
+                selected.insert(*port);
+                matched = true;
+            }
+            if let Some(ports) = allocated.get(value) {
+                selected.extend(ports.iter().copied());
+                matched = true;
+            }
+            if matched {
+                continue;
+            }
+            let port = value.parse::<u16>().map_err(|_| {
+                anyhow!(
+                    "unknown configured or allocated port name or invalid port number '{value}'"
+                )
+            })?;
+            if port == 0 {
+                bail!("port number must be between 1 and 65535");
+            }
+            selected.insert(port);
+        }
+    }
+    if selected.is_empty() {
+        bail!("no ports selected; configure [dev.ports], start a dynamic service, or provide port numbers");
+    }
+    Ok(selected.into_iter().collect())
+}
+
+pub fn kill_workspace_ports(
+    workspace_root: &Path,
+    ports: &[u16],
+    options: KillPortsOptions,
+) -> Result<()> {
+    kill_ports(ports, options)?;
+    if !options.dry_run {
+        prune_workspace_manifests(workspace_root)?;
+    }
+    Ok(())
 }
 
 pub fn kill_ports(ports: &[u16], options: KillPortsOptions) -> Result<()> {

--- a/src/dev/runner.rs
+++ b/src/dev/runner.rs
@@ -435,9 +435,6 @@ pub fn run_dev(
     drop(durable_log_tx);
     let _ = durable_log_handle.join();
     drop(control);
-    if let Some(signal) = executor::shutdown_signal() {
-        std::process::exit(128 + signal);
-    }
     run_result?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,10 +75,13 @@ fn run() -> Result<()> {
     {
         if !ports.is_empty() && ports.iter().all(|port| port.parse::<u16>().is_ok()) {
             let selected = aster::dev::resolve_port_selection(&HashMap::new(), ports)?;
-            return aster::dev::kill_ports(
-                &selected,
-                aster::dev::KillPortsOptions { dry_run: *dry_run },
-            );
+            let options = aster::dev::KillPortsOptions { dry_run: *dry_run };
+            return match find_workspace_root(&cwd) {
+                Some(workspace_root) => {
+                    aster::dev::kill_workspace_ports(&workspace_root, &selected, options)
+                }
+                None => aster::dev::kill_ports(&selected, options),
+            };
         }
     }
 
@@ -1023,8 +1026,16 @@ fn run() -> Result<()> {
                 let workspace_config = WorkspaceConfig::load(&workspace_root)?;
                 let configured =
                     aster::dev::resolve_static_dev_ports(&workspace_root, &workspace_config.dev)?;
-                let selected = aster::dev::resolve_port_selection(&configured, &ports)?;
-                aster::dev::kill_ports(&selected, aster::dev::KillPortsOptions { dry_run })?;
+                let selected = aster::dev::resolve_workspace_port_selection(
+                    &workspace_root,
+                    &configured,
+                    &ports,
+                )?;
+                aster::dev::kill_workspace_ports(
+                    &workspace_root,
+                    &selected,
+                    aster::dev::KillPortsOptions { dry_run },
+                )?;
             }
             ServicesCommands::Logs { .. } => unreachable!("service logs handled before discovery"),
             ServicesCommands::Tls { .. } => unreachable!("TLS commands handled before discovery"),

--- a/tests/dev_services.rs
+++ b/tests/dev_services.rs
@@ -34,6 +34,20 @@ fn occurrences(path: &Path, needle: &str) -> usize {
         .count()
 }
 
+fn allocation_manifest_count(lease_dir: &Path) -> usize {
+    fs::read_dir(lease_dir)
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with("allocation-") && name.ends_with(".json"))
+        })
+        .count()
+}
+
 fn process_is_running(pid: i32) -> bool {
     if unsafe { libc::kill(pid, 0) } == -1 {
         return false;
@@ -267,6 +281,7 @@ stream = true
             .contains(&format!("{start}:{derived_start}"))
             && TcpStream::connect(("127.0.0.1", start)).is_ok()
     });
+    assert_eq!(allocation_manifest_count(&lease_dir), 1);
 
     let mut second = launch();
     wait_until(Duration::from_secs(20), || {
@@ -275,12 +290,14 @@ stream = true
             .contains(&format!("{}:{}", start + 1, derived_start + 1))
             && TcpStream::connect(("127.0.0.1", start + 1)).is_ok()
     });
+    assert_eq!(allocation_manifest_count(&lease_dir), 2);
     assert!(first.try_wait().unwrap().is_none());
     assert!(second.try_wait().unwrap().is_none());
 
     terminate_aster(&mut first);
     wait_until(Duration::from_secs(5), || {
         TcpStream::connect(("127.0.0.1", start)).is_err()
+            && allocation_manifest_count(&lease_dir) == 1
     });
 
     let previous = occurrences(&events, &format!("{start}:{derived_start}"));
@@ -295,7 +312,129 @@ stream = true
     wait_until(Duration::from_secs(5), || {
         TcpStream::connect(("127.0.0.1", start)).is_err()
             && TcpStream::connect(("127.0.0.1", start + 1)).is_err()
+            && allocation_manifest_count(&lease_dir) == 0
     });
+}
+
+#[test]
+fn kill_ports_recovers_dynamic_listener_after_supervisor_crash() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let lease_dir = root.join("leases");
+    let reservation = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let port = reservation.local_addr().unwrap().port();
+    drop(reservation);
+
+    fs::create_dir(root.join(".git")).unwrap();
+    fs::create_dir(root.join("app")).unwrap();
+    fs::write(root.join("app/package.json"), r#"{"name":"app"}"#).unwrap();
+    fs::write(
+        root.join("aster.toml"),
+        format!(
+            r#"
+[dev.ports.http]
+allocation = "dynamic"
+range = [{port}, {port}]
+
+[dev.services.web]
+target = "//app:dev"
+port = "http"
+"#
+        ),
+    )
+    .unwrap();
+    fs::write(
+        root.join("app/aster.toml"),
+        r#"
+[targets.dev]
+command = "python3 -m http.server {port}"
+stream = true
+"#,
+    )
+    .unwrap();
+
+    let mut supervisor = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "up", "--no-ui", "--no-watch"])
+        .current_dir(root)
+        .env("ASTER_PORT_LEASE_DIR", &lease_dir)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_until(Duration::from_secs(20), || {
+        TcpStream::connect(("127.0.0.1", port)).is_ok()
+            && allocation_manifest_count(&lease_dir) == 1
+    });
+
+    let active_preview = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "kill-ports", "http", "--dry-run"])
+        .current_dir(root)
+        .env("ASTER_PORT_LEASE_DIR", &lease_dir)
+        .output()
+        .unwrap();
+    assert!(active_preview.status.success());
+    assert!(String::from_utf8_lossy(&active_preview.stdout).contains("Would terminate"));
+    assert!(supervisor.try_wait().unwrap().is_none());
+
+    // SIGKILL bypasses PortLease::drop, reproducing a supervisor crash while
+    // its independently running service process remains alive.
+    supervisor.kill().unwrap();
+    supervisor.wait().unwrap();
+    wait_until(Duration::from_secs(5), || {
+        TcpStream::connect(("127.0.0.1", port)).is_ok()
+    });
+    assert_eq!(allocation_manifest_count(&lease_dir), 1);
+
+    let other_workspace = temp.path().join("other-worktree");
+    fs::create_dir(&other_workspace).unwrap();
+    fs::create_dir(other_workspace.join(".git")).unwrap();
+    fs::write(
+        other_workspace.join("aster.toml"),
+        format!("[dev.ports.http]\nallocation = \"dynamic\"\nrange = [{port}, {port}]\n"),
+    )
+    .unwrap();
+    let isolated = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "kill-ports", "http", "--dry-run"])
+        .current_dir(&other_workspace)
+        .env("ASTER_PORT_LEASE_DIR", &lease_dir)
+        .output()
+        .unwrap();
+    assert!(!isolated.status.success());
+    assert!(String::from_utf8_lossy(&isolated.stderr).contains("unknown configured or allocated"));
+    assert!(TcpStream::connect(("127.0.0.1", port)).is_ok());
+
+    let preview = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "kill-ports", "http", "--dry-run"])
+        .current_dir(root)
+        .env("ASTER_PORT_LEASE_DIR", &lease_dir)
+        .output()
+        .unwrap();
+    assert!(
+        preview.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    assert!(String::from_utf8_lossy(&preview.stdout).contains("Would terminate"));
+    assert!(TcpStream::connect(("127.0.0.1", port)).is_ok());
+    assert_eq!(allocation_manifest_count(&lease_dir), 1);
+
+    let cleanup = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .args(["services", "kill-ports"])
+        .current_dir(root)
+        .env("ASTER_PORT_LEASE_DIR", &lease_dir)
+        .output()
+        .unwrap();
+    assert!(
+        cleanup.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&cleanup.stdout),
+        String::from_utf8_lossy(&cleanup.stderr)
+    );
+    wait_until(Duration::from_secs(5), || {
+        TcpStream::connect(("127.0.0.1", port)).is_err()
+            && allocation_manifest_count(&lease_dir) == 0
+    });
+    assert!(String::from_utf8_lossy(&cleanup.stdout).contains("Cleared"));
 }
 
 #[test]


### PR DESCRIPTION
## Root cause

`services kill-ports` intentionally stopped guessing dynamic values and only resolved static configuration. The allocator also retained no named bundle after a hard supervisor crash. Separately, `run_dev` called `process::exit` after graceful teardown, which skipped Rust destructors and prevented lifecycle-owned metadata cleanup.

## Fix

- persist each supervisor’s complete named allocation bundle in the host allocator directory, scoped by canonical worktree root
- remove manifests through normal RAII shutdown after child teardown
- retain manifests when SIGKILL bypasses cleanup, allowing `kill-ports` to resolve orphaned dynamic listeners by name
- resolve all active and crash-left allocations for the current worktree, including concurrent supervisors
- prune stale manifests only after their locks are released and complete port bundle is free
- let `run_dev` unwind to the existing top-level signal exit-code handler instead of calling `process::exit`

## Local validation

- real-process crash test: start dynamic HTTP service, SIGKILL only Aster, verify child remains, preview by dynamic name, clean by default selection, verify listener and manifest removed
- active allocation name resolution and dry-run preservation
- normal shutdown removes manifests
- concurrent supervisors retain independent manifests
- another worktree cannot resolve or kill the recorded allocation
- `cargo test --locked` (587 tests passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo doc --locked --no-deps --all-features`
- formatting, diff, and HTML parsing checks