### PR TITLE
Release Aster v0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.10.2"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Build orchestration for polyglot monorepos"


### PR DESCRIPTION
## Summary

- bump Aster from 0.10.2 to 0.11.0
- prepare the dynamic service-port allocation and recovery release

## Verification

- `cargo test --locked --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`
- `target/debug/aster --version`