### PR TITLE
Release Aster v0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.88"
 description = "Build orchestration for polyglot monorepos"


### PR DESCRIPTION
## Summary

- bump Aster from 0.11.0 to 0.11.1
- release running-service port reporting for dynamic, static, and portless services
- include the macOS lifecycle-test isolation and nonblocking allocation-manifest reads

## Verification

- `cargo test --locked --all-targets --all-features`
- `cargo fmt --all -- --check`
- `cargo check --locked --all-targets`
- `target/debug/aster --version`