### PR TITLE
Release Aster v0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.88"
 description = "Build orchestration for polyglot monorepos"


### PR DESCRIPTION
## Summary

- bump Aster from 0.11.1 to 0.11.2
- release preservation of the public Host authority through the TLS proxy
- include the GitHub Actions provenance dependency update

## Verification

- cargo test --locked --all-targets --all-features
- cargo fmt --all -- --check
- cargo check --locked --all-targets
- target/debug/aster --version