### PR TITLE
Release v0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,7 +147,7 @@ dependencies = [
 
 [[package]]
 name = "aster"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aster"
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.88"
 description = "Build orchestration for polyglot monorepos"


### PR DESCRIPTION
## Summary

1. Bump the Aster package version to `0.12.0`.
2. Update the locked root package version.

## Verification

- `cargo metadata --locked --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`