### PR TITLE
Stabilize macOS watcher synchronization tests

### DIFF
--- a/src/watch/event_loop.rs
+++ b/src/watch/event_loop.rs
@@ -1064,15 +1064,14 @@ mod tests {
 
         assert!(
             wait_until(|| dispatches.count() >= 2, Duration::from_secs(3)),
-            "dispatch #2 never fired. got count={}",
-            dispatches.count()
+            "dispatch #2 never fired. got count={dispatch_count}",
+            dispatch_count = dispatches.count()
         );
         let snapshot = dispatches.snapshot();
         assert_eq!(
             snapshot.len(),
             2,
-            "expected the mid-build source edit to survive cooldown; got dispatches: {:?}",
-            snapshot
+            "expected the mid-build source edit to survive cooldown; got dispatches: {snapshot:?}"
         );
 
         stop_loop(tx, shutdown, handle);

--- a/src/watch/event_loop.rs
+++ b/src/watch/event_loop.rs
@@ -1062,14 +1062,17 @@ mod tests {
         std::thread::sleep(Duration::from_millis(50));
         send_modify(&tx, "/repo/services/api/src/main.ts");
 
-        // Wait long enough for the queued edit to dispatch after the first
-        // build returns.
-        std::thread::sleep(Duration::from_millis(450));
+        assert!(
+            wait_until(|| dispatches.count() >= 2, Duration::from_secs(3)),
+            "dispatch #2 never fired. got count={}",
+            dispatches.count()
+        );
+        let snapshot = dispatches.snapshot();
         assert_eq!(
-            dispatches.count(),
+            snapshot.len(),
             2,
             "expected the mid-build source edit to survive cooldown; got dispatches: {:?}",
-            dispatches.snapshot()
+            snapshot
         );
 
         stop_loop(tx, shutdown, handle);

--- a/tests/watch_tests.rs
+++ b/tests/watch_tests.rs
@@ -325,12 +325,6 @@ fn watch_ignores_node_modules_changes() {
     setup_workspace(&tmp);
     write(&tmp, "libs/core/package.json", &nodejs_package("core"));
     write(&tmp, "libs/core/src/index.ts", "export const x = 1;\n");
-    write(
-        &tmp,
-        "libs/core/node_modules/foo/index.js",
-        "module.exports = 1;\n",
-    );
-
     let mut cmd = Command::new(aster_bin());
     cmd.current_dir(tmp.path())
         .arg("watch")
@@ -343,11 +337,13 @@ fn watch_ignores_node_modules_changes() {
     assert!(wait_for_line(&rx, "watching", Duration::from_secs(5)).is_some());
     drain_startup_events(&rx);
 
-    fs::write(
-        tmp.path().join("libs/core/node_modules/foo/index.js"),
-        "module.exports = 2;\n",
-    )
-    .unwrap();
+    // Model a dependency install creating node_modules after the watcher has
+    // started. The entire creation must remain ignored.
+    write(
+        &tmp,
+        "libs/core/node_modules/foo/index.js",
+        "module.exports = 1;\n",
+    );
 
     let observed = assert_no_line_containing(&rx, "change:", Duration::from_secs(2));
     kill_child(&mut child);


### PR DESCRIPTION
## Root cause

1. `source_events_during_dispatch_are_not_lost` assumed a second dispatch completed within a fixed 450 ms. On loaded macOS runners, the event was processed immediately after the assertion.
2. `watch_ignores_node_modules_changes` assumed a pre-created ignored directory remained present until mutation, producing an `ENOENT` setup failure.

## Fix

1. Wait for the observable second dispatch with the existing bounded synchronization helper, then retain the exact two-dispatch assertion.
2. Model dependency installation by creating the ignored `node_modules` tree after watcher startup with the existing fixture writer.

## Verification

- Event-loop regression: 50 consecutive passes
- Real watcher regression: 10 consecutive passes
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (590 passed)