### PR TITLE
feat: add named affected CI lanes

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -60,6 +60,58 @@ impl Address {
     }
 }
 
+/// A reusable selector for project addresses.
+///
+/// Supported forms are exact addresses (`//services/api`), recursive prefixes
+/// (`//services/...`), and the workspace-wide selector (`//...`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectSelector {
+    All,
+    Recursive(String),
+    Exact(String),
+}
+
+impl ProjectSelector {
+    pub fn parse(selector: &str) -> Result<Self> {
+        if selector == "//..." {
+            return Ok(Self::All);
+        }
+        if !selector.starts_with("//") {
+            return Err(anyhow!(
+                "project selector must start with '//': '{selector}'"
+            ));
+        }
+        if selector.contains(':') {
+            return Err(anyhow!(
+                "project selector must not include a target: '{selector}'"
+            ));
+        }
+        if let Some(prefix) = selector.strip_suffix("/...") {
+            if prefix == "//" || prefix.contains("...") {
+                return Err(anyhow!("invalid recursive project selector: '{selector}'"));
+            }
+            return Ok(Self::Recursive(prefix.to_string()));
+        }
+        if selector.contains("...") || selector.ends_with('/') {
+            return Err(anyhow!("invalid project selector: '{selector}'"));
+        }
+        Ok(Self::Exact(selector.to_string()))
+    }
+
+    pub fn matches(&self, project_address: &str) -> bool {
+        // Addresses are slash-delimited on every platform, while paths rendered
+        // by `Path::display` use the host separator on Windows.
+        let project_address = project_address.replace('\\', "/");
+        match self {
+            Self::All => true,
+            Self::Recursive(prefix) => {
+                project_address == *prefix || project_address.starts_with(&format!("{prefix}/"))
+            }
+            Self::Exact(address) => project_address == *address,
+        }
+    }
+}
+
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "//{}", self.path.display())?;
@@ -120,6 +172,37 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("must start with //"));
+    }
+
+    #[test]
+    fn project_selectors_match_exact_prefix_and_all() {
+        assert!(ProjectSelector::parse("//services/api")
+            .unwrap()
+            .matches("//services/api"));
+        assert!(!ProjectSelector::parse("//services/api")
+            .unwrap()
+            .matches("//services/api/web"));
+        assert!(ProjectSelector::parse("//services/...")
+            .unwrap()
+            .matches("//services/api/web"));
+        assert!(ProjectSelector::parse("//...")
+            .unwrap()
+            .matches("//services/api"));
+        assert!(ProjectSelector::parse("//services/...")
+            .unwrap()
+            .matches("//services\\api"));
+    }
+
+    #[test]
+    fn project_selectors_reject_paths_targets_and_malformed_recursion() {
+        for selector in [
+            "services/api",
+            "//services/api:test",
+            "//services/.../api",
+            "//services/",
+        ] {
+            assert!(ProjectSelector::parse(selector).is_err(), "{selector}");
+        }
     }
 
     #[test]

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -150,6 +150,10 @@ pub enum Commands {
         #[arg(long)]
         dependents: bool,
 
+        /// Select a configured named subset of affected primary projects
+        #[arg(long)]
+        lane: Option<String>,
+
         /// Show what would run without executing
         #[arg(long)]
         dry_run: bool,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -6,6 +6,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use crate::address::ProjectSelector;
 use crate::discovery::DiscoveredProject;
 use crate::graph::ProjectGraph;
 
@@ -216,37 +217,31 @@ pub fn select_projects<'a>(
     // Get cwd relative to workspace for ./... pattern
     let relative_cwd = cwd.strip_prefix(workspace_root).ok();
 
-    // Helper to check if a pattern matches a project address
+    // Absolute patterns use the shared selector grammar; ./... remains CLI-only.
     let matches_pattern = |pattern: &str, project_addr: &str| -> bool {
-        if pattern == "//..." {
-            // Match all projects
-            true
-        } else if let Some(prefix) = pattern.strip_suffix("/...") {
-            // Glob pattern: //prefix/... or ./...
-            let abs_prefix = if prefix == "." {
-                // ./... - use cwd
-                relative_cwd
-                    .map(|p| format!("//{}", p.display()))
-                    .unwrap_or_default()
-            } else if prefix.starts_with("./") {
-                // ./path/... - relative to cwd
-                relative_cwd
-                    .map(|p| format!("//{}/{}", p.display(), &prefix[2..]))
-                    .unwrap_or_default()
-            } else {
-                prefix.to_string()
-            };
-
-            if abs_prefix.is_empty() {
-                return false;
-            }
-
-            let prefix_with_slash = format!("{abs_prefix}/");
-            project_addr == abs_prefix || project_addr.starts_with(&prefix_with_slash)
-        } else {
-            // Exact match
-            project_addr == pattern
+        if pattern.starts_with("//") {
+            return ProjectSelector::parse(pattern)
+                .map(|selector| selector.matches(project_addr))
+                .unwrap_or(false);
         }
+
+        let Some(prefix) = pattern.strip_suffix("/...") else {
+            return false;
+        };
+        let abs_prefix = if prefix == "." {
+            relative_cwd
+                .map(|p| format!("//{}", p.display()))
+                .unwrap_or_default()
+        } else if prefix.starts_with("./") {
+            relative_cwd
+                .map(|p| format!("//{}/{}", p.display(), &prefix[2..]))
+                .unwrap_or_default()
+        } else {
+            return false;
+        };
+
+        !abs_prefix.is_empty()
+            && (project_addr == abs_prefix || project_addr.starts_with(&format!("{abs_prefix}/")))
     };
 
     // Check for //... in projects (means all)

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,8 +6,9 @@ pub use project::{
     TargetConfig,
 };
 pub use workspace::{
-    find_workspace_root, AffectedWorkspaceConfig, DetailedDevServiceGroupConfig, DevPortConfig,
-    DevServiceConfig, DevServiceGroupConfig, DevTlsProxyConfig, DevTlsRouteConfig,
-    DevWorkspaceConfig, DynamicDevPortConfig, DynamicPortAllocation, ResolvedDevPortConfig,
-    StaticPortAllocation, WatchWorkspaceConfig, WorkspaceConfig,
+    find_workspace_root, AffectedLaneConfig, AffectedWorkspaceConfig,
+    DetailedDevServiceGroupConfig, DevPortConfig, DevServiceConfig, DevServiceGroupConfig,
+    DevTlsProxyConfig, DevTlsRouteConfig, DevWorkspaceConfig, DynamicDevPortConfig,
+    DynamicPortAllocation, ResolvedDevPortConfig, StaticPortAllocation, WatchWorkspaceConfig,
+    WorkspaceConfig,
 };

--- a/src/config/workspace.rs
+++ b/src/config/workspace.rs
@@ -428,6 +428,22 @@ pub struct AffectedWorkspaceConfig {
     /// Workspace-relative glob patterns excluded from affected analysis.
     #[serde(default)]
     pub ignore: Vec<String>,
+
+    /// Named subsets of affected primary projects.
+    #[serde(default)]
+    pub lanes: HashMap<String, AffectedLaneConfig>,
+}
+
+/// Inclusive and exclusive project-address selectors for one affected lane.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AffectedLaneConfig {
+    /// Selectors admitted to the lane. Empty means all affected projects.
+    #[serde(default)]
+    pub include: Vec<String>,
+    /// Selectors removed from the lane. Exclusions always win.
+    #[serde(default)]
+    pub exclude: Vec<String>,
 }
 
 /// Watch-mode configuration controlling fs-event ignore and suppression behavior.
@@ -783,6 +799,10 @@ debounce_ms = 500
             r#"
 [affected]
 ignore = [".agents/**", ".claude/skills/**"]
+
+[affected.lanes.core]
+include = ["//src/elixir/core/..."]
+exclude = ["//src/elixir/core/generated"]
 "#,
         )
         .unwrap();
@@ -791,6 +811,14 @@ ignore = [".agents/**", ".claude/skills/**"]
         assert_eq!(
             config.affected.ignore,
             vec![".agents/**".to_string(), ".claude/skills/**".to_string()]
+        );
+        assert_eq!(
+            config.affected.lanes["core"].include,
+            vec!["//src/elixir/core/...".to_string()]
+        );
+        assert_eq!(
+            config.affected.lanes["core"].exclude,
+            vec!["//src/elixir/core/generated".to_string()]
         );
     }
 

--- a/src/git/ignore.rs
+++ b/src/git/ignore.rs
@@ -48,6 +48,7 @@ mod tests {
     fn filters_ignored_paths_and_keeps_other_paths() {
         let config = AffectedWorkspaceConfig {
             ignore: vec![".agents/**".to_string(), "docs/generated/**".to_string()],
+            ..AffectedWorkspaceConfig::default()
         };
         let ignore = AffectedIgnore::build(&config).unwrap();
         let paths = [
@@ -67,6 +68,7 @@ mod tests {
     fn rejects_invalid_patterns() {
         let config = AffectedWorkspaceConfig {
             ignore: vec!["[".to_string()],
+            ..AffectedWorkspaceConfig::default()
         };
 
         let error = AffectedIgnore::build(&config).err().unwrap();

--- a/src/git/lane.rs
+++ b/src/git/lane.rs
@@ -1,0 +1,77 @@
+//! Named project-address filtering for `aster affected` primary projects.
+
+use anyhow::{anyhow, Result};
+use std::collections::HashSet;
+
+use crate::address::ProjectSelector;
+use crate::config::AffectedWorkspaceConfig;
+use crate::discovery::DiscoveredProject;
+
+/// Apply a configured lane to affected project addresses.
+///
+/// Every configured selector must match at least one discovered project. Empty
+/// includes mean all affected projects, and exclusions always win.
+pub fn select_affected_lane(
+    lane_name: &str,
+    config: &AffectedWorkspaceConfig,
+    affected: HashSet<String>,
+    projects: &[DiscoveredProject],
+) -> Result<HashSet<String>> {
+    let lane = config.lanes.get(lane_name).ok_or_else(|| {
+        let mut known = config.lanes.keys().cloned().collect::<Vec<_>>();
+        known.sort();
+        if known.is_empty() {
+            anyhow!("unknown affected lane '{lane_name}'; no lanes are configured")
+        } else {
+            anyhow!(
+                "unknown affected lane '{}'; configured lanes: {}",
+                lane_name,
+                known.join(", ")
+            )
+        }
+    })?;
+
+    let addresses = projects
+        .iter()
+        .map(|project| format!("//{}", project.relative_path.display()))
+        .collect::<Vec<_>>();
+    let parse = |kind: &str, value: &str| -> Result<ProjectSelector> {
+        let selector = ProjectSelector::parse(value).map_err(|error| {
+            anyhow!(
+                "invalid selector '{}' in affected lane '{}' {}: {}",
+                value,
+                lane_name,
+                kind,
+                error
+            )
+        })?;
+        if !addresses.iter().any(|address| selector.matches(address)) {
+            return Err(anyhow!(
+                "selector '{}' in affected lane '{}' {} matches no projects",
+                value,
+                lane_name,
+                kind
+            ));
+        }
+        Ok(selector)
+    };
+
+    let includes = lane
+        .include
+        .iter()
+        .map(|value| parse("include", value))
+        .collect::<Result<Vec<_>>>()?;
+    let excludes = lane
+        .exclude
+        .iter()
+        .map(|value| parse("exclude", value))
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(affected
+        .into_iter()
+        .filter(|address| {
+            (includes.is_empty() || includes.iter().any(|selector| selector.matches(address)))
+                && !excludes.iter().any(|selector| selector.matches(address))
+        })
+        .collect())
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -6,7 +6,9 @@
 pub mod affected;
 pub mod file_owner;
 pub mod ignore;
+pub mod lane;
 
 pub use affected::AffectedDetector;
 pub use file_owner::{affected_with_dependents, files_to_projects};
 pub use ignore::AffectedIgnore;
+pub use lane::select_affected_lane;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,10 @@ use aster::executor::{
     collect_target_deps, compute_target_levels, install_signal_handler, parse_target_address,
     shutdown_signal, Executor,
 };
-use aster::git::{affected_with_dependents, files_to_projects, AffectedDetector, AffectedIgnore};
+use aster::git::{
+    affected_with_dependents, files_to_projects, select_affected_lane, AffectedDetector,
+    AffectedIgnore,
+};
 use aster::graph::{build_graph, build_target_graph, find_cycle, format_path};
 use aster::plugins::{PluginRegistry, Target, TargetCapability};
 use chrono::{DateTime, Utc};
@@ -459,6 +462,7 @@ fn run() -> Result<()> {
             base,
             head,
             dependents,
+            lane,
             dry_run,
             only_affected_files,
             warnings_as_errors,
@@ -519,11 +523,25 @@ fn run() -> Result<()> {
             let directly_affected_addrs = directly_affected.clone();
 
             // Expand with dependents if requested
-            let affected_addrs = if dependents {
+            let mut affected_addrs = if dependents {
                 affected_with_dependents(directly_affected, &graph)
             } else {
                 directly_affected
             };
+
+            // Lane selection applies only to primary projects, after optional
+            // dependent expansion and before target dependency closure.
+            if let Some(lane_name) = lane.as_deref() {
+                affected_addrs = select_affected_lane(
+                    lane_name,
+                    &workspace_config.affected,
+                    affected_addrs,
+                    &projects,
+                )?;
+                if output_mode == OutputMode::Verbose {
+                    eprintln!("[aster] Affected lane '{lane_name}': {affected_addrs:?}");
+                }
+            }
 
             // Primary projects are the affected ones (only these run the requested target)
             let primary_addrs: HashSet<String> = affected_addrs.iter().cloned().collect();
@@ -559,11 +577,13 @@ fn run() -> Result<()> {
                 );
             }
 
-            // Print affected projects list (unless quiet or json without dry_run)
-            if output_mode != OutputMode::Quiet && (output_mode != OutputMode::Json || dry_run) {
+            // Machine-readable output must contain JSON only, including dry runs.
+            if output_mode != OutputMode::Quiet && output_mode != OutputMode::Json {
                 println!(
                     "Affected projects ({}):",
-                    if dependents {
+                    if lane.is_some() {
+                        "selected by lane"
+                    } else if dependents {
                         "including dependents"
                     } else {
                         "directly affected only"
@@ -610,14 +630,12 @@ fn run() -> Result<()> {
                 // Categorize each target's rationale
                 let rationale_for = |target_addr: &str| -> &'static str {
                     if let Some((project_addr, target_name)) = parse_target_address(target_addr) {
-                        if target_name == target {
-                            // This is the requested target
+                        if target_name == target && primary_addrs.contains(&project_addr) {
+                            // Only lane-selected requested targets are primary work.
                             if directly_affected_addrs.contains(&project_addr) {
                                 return "affected";
-                            } else if primary_addrs.contains(&project_addr) {
-                                // In primary but not directly affected = added by --dependents
-                                return "dependent";
                             }
+                            return "dependent";
                         }
                     }
                     "target dependency"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1685,6 +1685,264 @@ fn test_affected_with_dependents_flag() {
 }
 
 #[test]
+fn test_affected_lanes_split_elixir_primary_projects_and_keep_target_dependencies() {
+    let tmp = TempDir::new().unwrap();
+    setup_git_repo(&tmp);
+
+    let mix_project = |module: &str, app: &str| {
+        format!(
+            "defmodule {module}.MixProject do\n  use Mix.Project\n  def project, do: [app: :{app}, version: \"0.1.0\"]\nend\n"
+        )
+    };
+    write_mix_exs(
+        &tmp,
+        "src/elixir/core/accounts/mix.exs",
+        &mix_project("Accounts", "accounts"),
+    );
+    write_mix_exs(
+        &tmp,
+        "services/platform/gateway/mix.exs",
+        &mix_project("Gateway", "gateway"),
+    );
+    write_aster_toml(
+        &tmp,
+        "aster.toml",
+        r#"
+[affected.lanes.core]
+include = ["//src/elixir/core/..."]
+
+[affected.lanes.platform]
+include = ["//services/platform/..."]
+
+[affected.lanes.with_exclusion]
+exclude = ["//services/platform/..."]
+"#,
+    );
+    write_aster_toml(
+        &tmp,
+        "src/elixir/core/accounts/aster.toml",
+        r#"
+[targets.build]
+command = "true"
+depends_on = ["//services/platform/gateway:prepare"]
+"#,
+    );
+    write_aster_toml(
+        &tmp,
+        "services/platform/gateway/aster.toml",
+        r#"
+[targets.build]
+command = "true"
+
+[targets.prepare]
+command = "true"
+"#,
+    );
+    git_commit(&tmp, "Initial commit");
+    write_fixture(&tmp, "src/elixir/core/accounts/lib/change.ex", "changed");
+    write_fixture(&tmp, "services/platform/gateway/lib/change.ex", "changed");
+
+    let run_lane = |name: &str| {
+        Command::new(env!("CARGO_BIN_EXE_aster"))
+            .current_dir(tmp.path())
+            .args([
+                "affected",
+                "build",
+                "--base=HEAD",
+                "--dry-run",
+                "--json",
+                "--lane",
+                name,
+            ])
+            .output()
+            .unwrap()
+    };
+
+    let core = run_lane("core");
+    assert!(core.status.success(), "core lane failed: {core:?}");
+    let core_json: serde_json::Value = serde_json::from_slice(&core.stdout).unwrap();
+    let core_targets = core_json["targets"].as_array().unwrap();
+    assert!(core_targets.iter().any(|target| {
+        target["address"] == "//src/elixir/core/accounts:build" && target["reason"] == "affected"
+    }));
+    assert!(core_targets.iter().any(|target| {
+        target["address"] == "//services/platform/gateway:prepare"
+            && target["reason"] == "target dependency"
+    }));
+    assert!(!core_targets
+        .iter()
+        .any(|target| target["address"] == "//services/platform/gateway:build"));
+
+    let platform = run_lane("platform");
+    assert!(
+        platform.status.success(),
+        "platform lane failed: {platform:?}"
+    );
+    let platform_stdout = String::from_utf8_lossy(&platform.stdout);
+    assert!(platform_stdout.contains("//services/platform/gateway:build"));
+    assert!(!platform_stdout.contains("//src/elixir/core/accounts:build"));
+
+    let excluded = run_lane("with_exclusion");
+    assert!(
+        excluded.status.success(),
+        "excluded lane failed: {excluded:?}"
+    );
+    let excluded_stdout = String::from_utf8_lossy(&excluded.stdout);
+    assert!(excluded_stdout.contains("//src/elixir/core/accounts:build"));
+    assert!(!excluded_stdout.contains("//services/platform/gateway:build"));
+}
+
+#[test]
+fn test_affected_lane_filters_after_dependents_expansion() {
+    let tmp = TempDir::new().unwrap();
+    setup_git_repo(&tmp);
+    write_package_json(
+        &tmp,
+        "src/elixir/core/accounts/package.json",
+        r#"{"name":"accounts","scripts":{"build":"true"}}"#,
+    );
+    write_package_json(
+        &tmp,
+        "services/platform/gateway/package.json",
+        r#"{"name":"gateway","dependencies":{"accounts":"file:../../../src/elixir/core/accounts"},"scripts":{"build":"true"}}"#,
+    );
+    write_aster_toml(
+        &tmp,
+        "aster.toml",
+        "[affected.lanes.platform]\ninclude = [\"//services/platform/...\"]\n",
+    );
+    git_commit(&tmp, "Initial commit");
+    write_fixture(&tmp, "src/elixir/core/accounts/change.js", "changed");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args([
+            "affected",
+            "build",
+            "--base=HEAD",
+            "--dependents",
+            "--lane",
+            "platform",
+            "--dry-run",
+        ])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "lane failed: {output:?}");
+    assert!(stdout.contains("//services/platform/gateway:build"));
+    assert!(
+        stdout.contains("//src/elixir/core/accounts:build  (target dependency)"),
+        "expected filtered direct project to remain a target dependency: {stdout}"
+    );
+}
+
+#[test]
+fn test_affected_lane_validates_unknown_malformed_and_non_matching_selectors() {
+    for (configuration, lane, expected) in [
+        (
+            "[affected.lanes.core]\ninclude = [\"src/elixir/core/...\"]\n",
+            "core",
+            "invalid selector 'src/elixir/core/...' in affected lane 'core' include",
+        ),
+        (
+            "[affected.lanes.core]\ninclude = [\"//missing/...\"]\n",
+            "core",
+            "selector '//missing/...' in affected lane 'core' include matches no projects",
+        ),
+        (
+            "[affected.lanes.core]\ninclude = [\"//src/elixir/core/...\"]\n",
+            "other",
+            "unknown affected lane 'other'; configured lanes: core",
+        ),
+    ] {
+        let tmp = TempDir::new().unwrap();
+        setup_git_repo(&tmp);
+        write_mix_exs(
+            &tmp,
+            "src/elixir/core/accounts/mix.exs",
+            "defmodule Accounts.MixProject do\n  use Mix.Project\n  def project, do: [app: :accounts, version: \"0.1.0\"]\nend\n",
+        );
+        write_aster_toml(&tmp, "aster.toml", configuration);
+        git_commit(&tmp, "Initial commit");
+        write_fixture(&tmp, "src/elixir/core/accounts/lib/change.ex", "changed");
+
+        let output = Command::new(env!("CARGO_BIN_EXE_aster"))
+            .current_dir(tmp.path())
+            .args(["affected", "build", "--base=HEAD", "--lane", lane])
+            .output()
+            .unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "expected failure: {output:?}");
+        assert!(stderr.contains(expected), "expected {expected:?}: {stderr}");
+    }
+}
+
+#[test]
+fn test_affected_lane_empty_selection_uses_existing_output_contracts() {
+    let tmp = TempDir::new().unwrap();
+    setup_git_repo(&tmp);
+    write_package_json(
+        &tmp,
+        "src/elixir/core/accounts/package.json",
+        r#"{"name":"accounts","scripts":{"test":"true"}}"#,
+    );
+    write_package_json(
+        &tmp,
+        "services/platform/gateway/package.json",
+        r#"{"name":"gateway","scripts":{"test":"true"}}"#,
+    );
+    write_aster_toml(
+        &tmp,
+        "aster.toml",
+        "[affected.lanes.platform]\ninclude = [\"//services/platform/...\"]\n",
+    );
+    git_commit(&tmp, "Initial commit");
+    write_fixture(&tmp, "src/elixir/core/accounts/change.js", "changed");
+
+    let human = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args(["affected", "test", "--base=HEAD", "--lane", "platform"])
+        .output()
+        .unwrap();
+    assert!(human.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&human.stdout).trim(),
+        "No projects affected"
+    );
+
+    let json = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args([
+            "--json",
+            "affected",
+            "test",
+            "--base=HEAD",
+            "--lane",
+            "platform",
+        ])
+        .output()
+        .unwrap();
+    assert!(json.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    assert_eq!(value["summary"]["total"], 0);
+
+    let quiet = Command::new(env!("CARGO_BIN_EXE_aster"))
+        .current_dir(tmp.path())
+        .args([
+            "--quiet",
+            "affected",
+            "test",
+            "--base=HEAD",
+            "--lane",
+            "platform",
+        ])
+        .output()
+        .unwrap();
+    assert!(quiet.status.success());
+    assert!(quiet.stdout.is_empty() && quiet.stderr.is_empty());
+}
+
+#[test]
 fn test_affected_help_shows_command() {
     let output = Command::new(env!("CARGO_BIN_EXE_aster"))
         .args(["affected", "--help"])


### PR DESCRIPTION
## Summary

- add named `[affected.lanes.<name>]` configuration with `include` and `exclude` project selectors
- add `aster affected <target> --lane <name>`
- apply lane filtering after optional dependent expansion and before target-dependency closure
- reuse exact, recursive-prefix, and all-project selector semantics
- preserve required target dependencies outside the selected lane
- validate lane names and selectors with actionable errors

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (full suite passed in Factory verification)
- focused affected-lane integration tests, including the First Landing-shaped Elixir split
- Windows path-separator regression coverage
